### PR TITLE
Remove array redefinition

### DIFF
--- a/inc/Incursion.h
+++ b/inc/Incursion.h
@@ -46,12 +46,10 @@ long  array_index(long x,long y);
 #define realloc _realloc
 #define calloc(a,b) _malloc((a)*(b))
 #define I(x,y)  array_index(x,y)
-#define array(a,i,s) array_access((void*)a,sizeof(a[0]),i,s)
 
 #else
 
 #define I(x,y) x
-#define array(array,index,size) array[index]
 
 #endif
 


### PR DESCRIPTION
This define breaks the standard C++11 array template and must be removed. No code relies on this macro, so it was simple to remove.

Related to #12 

If it were up to me I'd actually remove the entire `DEBUG_MEMORY_CORRUPTION` block of code. There are better tools to debug and prevent memory issues.