### PR TITLE
Switch to standard types, replace long types

### DIFF
--- a/inc/Base.h
+++ b/inc/Base.h
@@ -44,7 +44,7 @@ template<class S, int32 Initial, int32 Delta>
       void Clear() { Count = 0; }; 
 	};
 
-extern long ZeroValue;
+extern int ZeroValue;
 
 template<class S,int32 Initial,int32 Delta>
   class NArray : public Array<S,Initial,Delta>

--- a/inc/Defines.h
+++ b/inc/Defines.h
@@ -25,22 +25,24 @@
 #ifndef ICOMP
 #define __MINMAX_DEFINED
 
-typedef signed char         int8;
-typedef signed short        int16;
-typedef unsigned char       uint8;
-typedef unsigned short      uint16;
-typedef unsigned long       uint32;
-typedef signed long         int32;
-typedef unsigned long       rID;
-typedef signed char         Dir;
-typedef void*               Param;
-typedef uint32              Glyph;
-typedef int8                EvReturn;
+#include <cstdint>
 
-typedef signed long       hText;
-typedef signed long       hCode;
-typedef signed long       hData;
-typedef signed long       hObj;
+typedef int8_t int8;
+typedef int16_t int16;
+typedef uint8_t uint8;
+typedef uint16_t uint16;
+typedef uint32_t uint32;
+typedef int32_t int32;
+typedef uint32_t rID;
+typedef int8_t Dir;
+typedef void* Param;
+typedef uint32_t Glyph;
+typedef int8_t EvReturn;
+
+typedef signed long hText;
+typedef signed long hCode;
+typedef int hData;
+typedef signed long hObj;
 
 #define OBJ_TABLE_SIZE   65536
 /* ww: was 4096, but a recent profile revealed Registry::Get() to be 

--- a/inc/Globals.h
+++ b/inc/Globals.h
@@ -9,8 +9,8 @@ class String;
 void Fatal(const char*,...);
 void Error(const char*,...);
 
-void init_genrand(unsigned long s);
-unsigned long genrand_int32(void);
+void init_genrand(uint32_t s);
+uint32_t genrand_int32(void);
 
 int16 strcatf(char*,const char*,...);
 inline int16 random(int16 mx);

--- a/inc/Map.h
+++ b/inc/Map.h
@@ -646,9 +646,9 @@ class Thing: public Object
 	{
     ARCHIVE_CLASS(Thing,Object,r)
       if (isSave)
-        *((long*)&hm) = m ? m->myHandle : 0; 
+        hm = m ? m->myHandle : 0;
       else
-        m = oMap((long)hm);
+        m = oMap(hm);
       Named.Serialize(r);
       __Stati.Serialize(r);
       backRefs.Serialize(r); 

--- a/src/Base.cpp
+++ b/src/Base.cpp
@@ -478,7 +478,7 @@ SkipThisFree:
 
 
 
-long ZeroValue = 0;                            
+int ZeroValue = 0;
 
 template<class S,int32 Initial,int32 Delta>
   Array<S,Initial,Delta>::Array()
@@ -1256,11 +1256,11 @@ void SymbolTable::Bind(int32 id, Binding *b)
 #define UPPER_MASK 0x80000000UL /* most significant w-r bits */
 #define LOWER_MASK 0x7fffffffUL /* least significant r bits */
 
-static unsigned long mt[N]; /* the array for the state vector  */
+static uint32_t mt[N]; /* the array for the state vector  */
 static int mti=N+1; /* mti==N+1 means mt[N] is not initialized */
 
 /* initializes mt[N] with a seed */
-void init_genrand(unsigned long s)
+void init_genrand(uint32_t s)
 {
     mt[0]= s & 0xffffffffUL;
     for (mti=1; mti<N; mti++) {
@@ -1279,7 +1279,7 @@ void init_genrand(unsigned long s)
 /* init_key is the array for initializing keys */
 /* KY_length is its length */
 /* slight change for C++, 2004/2/26 */
-void init_by_array(unsigned long init_key[], int KY_length)
+void init_by_array(uint32_t init_key[], int KY_length)
 {
     int i, j, k;
     init_genrand(19650218UL);
@@ -1305,10 +1305,10 @@ void init_by_array(unsigned long init_key[], int KY_length)
 }
 
 /* generates a random number on [0,0xffffffff]-interval */
-unsigned long genrand_int32(void)
+uint32_t genrand_int32(void)
 {
-    unsigned long y;
-    static unsigned long mag01[2]={0x0UL, MATRIX_A};
+    uint32_t y;
+    static uint32_t mag01[2]={0x0UL, MATRIX_A};
     /* mag01[x] = x * MATRIX_A  for x=0,1 */
 
     if (mti >= N) { /* generate N words at one time */
@@ -1343,9 +1343,9 @@ unsigned long genrand_int32(void)
 }
 
 /* generates a random number on [0,0x7fffffff]-interval */
-long genrand_int31(void)
+int genrand_int31(void)
 {
-    return (long)(genrand_int32()>>1);
+    return (int)(genrand_int32()>>1);
 }
 
 /* generates a random number on [0,1]-real-interval */
@@ -1372,7 +1372,7 @@ double genrand_real3(void)
 /* generates a random number on [0,1) with 53-bit resolution*/
 double genrand_res53(void) 
 { 
-    unsigned long a=genrand_int32()>>5, b=genrand_int32()>>6; 
+    uint32_t a=genrand_int32()>>5, b=genrand_int32()>>6;
     return(a*67108864.0+b)*(1.0/9007199254740992.0); 
 } 
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -178,7 +178,7 @@ Resurrected:
     pp->MyTerm->RefreshMap();
 
     time(&tm);
-    srand((unsigned long)tm);
+    srand((uint32_t)tm);
 
     /* NOTE(rmtew): This is the main game loop.  Once we're in here, we have to
                     pretty much die or save and exit the game, to exit the

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -501,7 +501,7 @@ PutName:
             str = Tag1;
             if (((int)(Subject)) < 0x000FFFFF) {
                 Error("Probable parameter mismatch in __XPrint; msg = \"%s\","
-                    " POV=%d, Subject=%d", msg, (long)POV, (long)Subject);
+                    " POV=%p, Subject=%p", msg, POV, Subject);
                 Error("Probable parameter mismatch in __XPrint; msg = \"%s\","
                     " POV=%s, Subject=%s", msg, (const char*)POV->Name(0), (const char*)Subject->Name(0));
                 return msg;

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -2354,7 +2354,7 @@ void Monster::PreBuff()
           */
     if ( (Effs[i].Purpose & EP_BUFF) && 
         !(Effs[i].Purpose & EP_PLAYER_ONLY) &&
-         ((long)Effs[i].Source <= 1) && 
+         ((intptr_t)Effs[i].Source <= 1) &&
         (te->HasFlag(EF_DXLONG) || te->HasFlag(EF_PERSISTANT) ||
           ( te->HasFlag(EF_DLONG) && random(100) < 25)) &&
         (te->PEvent(EV_ISTARGET,this,eID) == SHOULD_CAST_IT) &&
@@ -2370,7 +2370,7 @@ void Monster::PreBuff()
       e.EActor = this; 
       e.EVictim = this; 
       e.EMap = this->m;
-      if ((long)Effs[nEff].Source == 1)       e.Event = EV_INVOKE;
+      if ((intptr_t)Effs[nEff].Source == 1)       e.Event = EV_INVOKE;
       else                                    e.Event = EV_CAST;
       Magic::MagicEvent(e); 
     } 

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -164,9 +164,9 @@ void Registry::Block(void **Block, size_t sz)
     ASSERT(theRegistry->Get(hCurrent));
 
     if (saveMode)
-      *((long*)Block) = RegisterBlock(*Block,hCurrent,sz);
+      *((int*)Block) = RegisterBlock(*Block,hCurrent,sz);
      else
-      *Block = GetData(*((long*)Block));
+      *Block = GetData(*((int*)Block));
   } 
 
 

--- a/src/Skills.cpp
+++ b/src/Skills.cpp
@@ -3851,7 +3851,7 @@ void Character::RecalcCraftFormulas() {
 	//if (outOfFormulas)
 	//  IPrint("Out of formulas!");
 	time(&t);
-	srand((unsigned long)t);
+	srand((uint32_t)t);
 }
 
 int16 Creature::getFavEnemyBonus(Creature *cr)
@@ -5096,7 +5096,7 @@ void Player::WildShape()
 		}
 	}
 	mID = MyTerm->LMenu(MENU_ESC | MENU_DESC | MENU_3COLS | MENU_SORTED, "Wild Shape Into What Type of Creature?", WIN_MAP, 0);
-	if ((long)mID <= 0 || mID == (rID)-1) return;
+	if ((int)mID <= 0 || mID == (rID)-1) return;
 
 	if (!LoseFatigue(1, true))
 		return;

--- a/src/Social.cpp
+++ b/src/Social.cpp
@@ -2222,7 +2222,7 @@ void Player::WildShape() {
     }
     rID mid = MyTerm->LMenu(MENU_ESC|MENU_DESC|MENU_3COLS|MENU_SORTED,
         "Wild Shape Into What Type of Creature?", WIN_MAP,0);
-    if (mid == (unsigned long)-1) return;
+    if (mid == (uint32_t)-1) return;
 
     IPrint("You turn into a <Res>.",mid);
     Shapeshift(mid,true,NULL);   
@@ -2271,7 +2271,7 @@ void Player::SummonDruidAnimal() {
     }
     rID mid = MyTerm->LMenu(MENU_ESC|MENU_DESC|MENU_3COLS|MENU_SORTED,
         "What Type of Animal Companion?", WIN_MAP,0);
-    if (mid == (unsigned long)-1) return;
+    if (mid == (uint32_t)-1) return;
 
     // have we already done this today? 
     if (HasStati(TRIED,(int8)HAS_DRUID_ANIMAL,NULL)) {

--- a/src/Values.cpp
+++ b/src/Values.cpp
@@ -214,7 +214,7 @@ tm:
         AttrAdj[at][BONUS_TEMP] = 0;                                                    \
     } else if (tm.VType == MVAL_PERCENT && percent_attr(at))                            \
         AttrAdj[at][BONUS_TEMP] = (int8)(((((AttrAdj[at][BONUS_TEMP]*5+100L)*           \
-                                  ((long)tm.Adjust(100))) / 100L) - 100) / 5);          \
+                                  ((int)tm.Adjust(100))) / 100L) - 100) / 5);           \
      else                                                                               \
          AttrAdj[at][BONUS_TEMP] = tm.Adjust(AttrAdj[at][BONUS_BASE]                    \
        + AttrAdj[at][BONUS_TEMP]) - (AttrAdj[at][BONUS_BASE] /*+ AttrAdj[at][BONUS_TEMP]*/);  

--- a/src/Wcurses.cpp
+++ b/src/Wcurses.cpp
@@ -1218,7 +1218,7 @@ int16 cursesTerm::GetCharCmd(KeyCmdMode mode) {
     for(;;) {
 		uint32 ticks0 = GetElapsedMilli(), ticks1;
         int key = readkey(0);
-		unsigned long key_modifiers = PDC_get_key_modifiers();
+		uint32_t key_modifiers = PDC_get_key_modifiers();
 
         if (Mode == MO_PLAY && p->UpdateMap)
             RefreshMap();


### PR DESCRIPTION
Includes `<cstdint>` and updates typedefs to point to it so that I don't need to go around the entire source and update every single type.

Replace `long` with `int` in any place where the type is used for a plain value. This clarifies that nothing is broken here.

Generally use `int` as the "don't care" type. `int` always means `int32_t` on modern compilers on all platforms. This is convention.

`unsigned long` becomes `uint32_t`.

`printf` function which was converting pointers to int to print them now uses `%p` instead to print the pointer directly. This might be left over debug code actually.

`EffectInfo::Source` is a suspicious union-like type of pointer and enum types. I used `intptr_t` here for comparisons to prevent truncation.

Did not touch `long` in preprocessor or tokenizer sources. Not much I can do with these for now.