### PR TITLE
Remove modified character checking functions

### DIFF
--- a/inc/Base.h
+++ b/inc/Base.h
@@ -12,11 +12,6 @@
 #define Check(a,b) { if (!(a)) Fatal(b);  }
 #define iswhite(ch) ((ch) == 13 || (ch) == ' ' || (ch) == '\t' || \
                        (ch) == 10)
-                       
-#define isspace(ch) isspace(max(ch,1))
-#define isalpha(ch) isalpha(max(ch,1))
-#define isalnum(ch) isalnum(max(ch,1))
-#define isdigit(ch) isdigit(max(ch,1))
 
 #define SC(xx) (*tmpstr((const char*)xx))
 


### PR DESCRIPTION
Looking up [the standard docs](https://en.cppreference.com/w/cpp/string/byte), 0x00 characters have the same results as 0x01. I can't find any way to explain or justify these macros, casting to `unsigned char` would've been more correct. Behavior is defined for ASCII characters, and for non-ASCII these are not the right tools anyways.

Related to #12