### PR TITLE
Replace min/max macros with standard C++

### DIFF
--- a/build/Incursion.vcxproj
+++ b/build/Incursion.vcxproj
@@ -28,23 +28,23 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -120,6 +120,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -173,6 +174,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -226,6 +228,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -272,6 +275,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/build/exe_curses.vcxproj
+++ b/build/exe_curses.vcxproj
@@ -27,25 +27,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/build/exe_libtcod.vcxproj
+++ b/build/exe_libtcod.vcxproj
@@ -27,26 +27,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -141,6 +141,7 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       <ProgramDataBaseFileName>$(IntDir)$(SolutionName).pdb</ProgramDataBaseFileName>
       <PreprocessorDefinitions>_UNICODE;LIBTCOD_TERM;TCOD_SDL2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\inc;..\dependencies\libtcod-1.7.0-x86-msvc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -165,6 +166,7 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       <ProgramDataBaseFileName>$(IntDir)$(SolutionName).pdb</ProgramDataBaseFileName>
       <PreprocessorDefinitions>_UNICODE;LIBTCOD_TERM;TCOD_SDL2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\inc;..\dependencies\libtcod-1.7.0-x86_64-msvc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -192,6 +194,7 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       <ProgramDataBaseFileName>$(IntDir)$(SolutionName).pdb</ProgramDataBaseFileName>
       <PreprocessorDefinitions>_UNICODE;LIBTCOD_TERM;TCOD_SDL2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\inc;..\dependencies\libtcod-1.7.0-x86-msvc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -218,6 +221,7 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       <ProgramDataBaseFileName>$(IntDir)$(SolutionName).pdb</ProgramDataBaseFileName>
       <PreprocessorDefinitions>_UNICODE;LIBTCOD_TERM;TCOD_SDL2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\inc;..\dependencies\libtcod-1.7.0-x86_64-msvc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/build/modaccent.vcxproj
+++ b/build/modaccent.vcxproj
@@ -53,27 +53,27 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/inc/Base.h
+++ b/inc/Base.h
@@ -4,7 +4,7 @@
    OArray, Dice, String, MVal, Rect, Fraction,
    Object and Registry. 
 */
-
+#include <algorithm>
 
 #define BIT(bitnum) (1 << (bitnum - 1))
 #define XBIT(a)     (1 << (a))
@@ -184,7 +184,7 @@ struct MVal
           nval = oval;
          break;
         case MVAL_ADD:
-          nval = max(0,oval+Value);
+          nval = std::max(0,oval+Value);
          break;
         case MVAL_SET:
           nval = Value;
@@ -199,16 +199,16 @@ struct MVal
         case MBOUND_NONE:
           break;
         case MBOUND_MIN:
-          nval = max<int16_t>(Bound,nval);
+          nval = std::max<int16_t>(Bound,nval);
          break;
         case MBOUND_MAX:
-          nval = min<int16_t>(Bound,nval);
+          nval = std::min<int16_t>(Bound,nval);
          break;
         case MBOUND_NEAR:
           if (nval >= oval)
-            nval = max<int16_t>(nval,(nval+Bound*2)/3);
+            nval = std::max<int16_t>(nval,(nval+Bound*2)/3);
           else
-            nval = max<int16_t>(nval,(nval+Bound*2)/3);
+            nval = std::max<int16_t>(nval,(nval+Bound*2)/3);
          break;
         default:
           Error("MVal::Adjust -- illegal BType!");
@@ -272,8 +272,8 @@ struct Rect
     Rect() = default;
     /// <summary>Initialize a Rect respecting the invariant.</summary>
     Rect(uint8 _x1, uint8 _y1, uint8 _x2, uint8 _y2) noexcept
-      : x1{min(_x1, _x2)}, y1{min(_y1, _y2)},
-        x2{max(_x1, _x2)}, y2{max(_y1, _y2)} {}
+      : x1{std::min(_x1, _x2)}, y1{std::min(_y1, _y2)},
+        x2{std::max(_x1, _x2)}, y2{std::max(_y1, _y2)} {}
     /// <summary>Set this Rect's values respecting the invariant.</summary>
     void Set(uint8 _x1, uint8 _y1, uint8 _x2, uint8 _y2) noexcept
       { *this = Rect{_x1, _y1, _x2, _y2}; }
@@ -292,7 +292,7 @@ struct Rect
           }
         else
           {
-            inner.x1 = x1 + 1 + random(max(0,((x2-x1)-2)-width));
+            inner.x1 = x1 + 1 + random(std::max(0,((x2-x1)-2)-width));
             inner.x2 = inner.x1 + width;
           }
         if (height >= (y2-y1))
@@ -302,7 +302,7 @@ struct Rect
           }
         else
           {
-            inner.y1 = y1 + 1 + random(max(0,((y2-y1)-2)-height));
+            inner.y1 = y1 + 1 + random(std::max(0,((y2-y1)-2)-height));
             inner.y2 = inner.y1 + height;
           }
         return inner;
@@ -314,15 +314,15 @@ struct Rect
     Rect PlaceWithinSafely(uint8 width, uint8 height) const
       {
         Rect inner{};
-        inner.x1 = x1 + random(max(0,((x2-x1)-1)-width));
+        inner.x1 = x1 + random(std::max(0,((x2-x1)-1)-width));
         inner.x2 = inner.x1 + width;
-        inner.y1 = y1 + random(max(0,((y2-y1)-1)-height));
+        inner.y1 = y1 + random(std::max(0,((y2-y1)-1)-height));
         inner.y2 = inner.y1 + height;
 
-        inner.x1 = max<int>(inner.x1, x1 + 2);
-        inner.y1 = max<int>(inner.y1, y1 + 2);
-        inner.x2 = min<int>(inner.x2, x2 - 2);
-        inner.y2 = min<int>(inner.y2, y2 - 2);
+        inner.x1 = std::max<int>(inner.x1, x1 + 2);
+        inner.y1 = std::max<int>(inner.y1, y1 + 2);
+        inner.x2 = std::min<int>(inner.x2, x2 - 2);
+        inner.y2 = std::min<int>(inner.y2, y2 - 2);
         return inner;
       }
     /// <summary>Return true if `x` and `y` are within this rect (inclusive).</summary>

--- a/inc/Base.h
+++ b/inc/Base.h
@@ -199,16 +199,16 @@ struct MVal
         case MBOUND_NONE:
           break;
         case MBOUND_MIN:
-          nval = max(Bound,nval);
+          nval = max<int16_t>(Bound,nval);
          break;
         case MBOUND_MAX:
-          nval = min(Bound,nval);
+          nval = min<int16_t>(Bound,nval);
          break;
         case MBOUND_NEAR:
           if (nval >= oval)
-            nval = max(nval,(nval+Bound*2)/3);
+            nval = max<int16_t>(nval,(nval+Bound*2)/3);
           else
-            nval = max(nval,(nval+Bound*2)/3);
+            nval = max<int16_t>(nval,(nval+Bound*2)/3);
          break;
         default:
           Error("MVal::Adjust -- illegal BType!");
@@ -319,10 +319,10 @@ struct Rect
         inner.y1 = y1 + random(max(0,((y2-y1)-1)-height));
         inner.y2 = inner.y1 + height;
 
-        inner.x1 = max(inner.x1, x1 + 2);
-        inner.y1 = max(inner.y1, y1 + 2);
-        inner.x2 = min(inner.x2, x2 - 2);
-        inner.y2 = min(inner.y2, y2 - 2);
+        inner.x1 = max<int>(inner.x1, x1 + 2);
+        inner.y1 = max<int>(inner.y1, y1 + 2);
+        inner.x2 = min<int>(inner.x2, x2 - 2);
+        inner.y2 = min<int>(inner.y2, y2 - 2);
         return inner;
       }
     /// <summary>Return true if `x` and `y` are within this rect (inclusive).</summary>

--- a/inc/Creature.h
+++ b/inc/Creature.h
@@ -230,7 +230,7 @@ class Creature: public Thing, public Magic
       virtual int16 getDef() {
           if (StateFlags & MS_STILL_CAST) {
               CalcValues();
-              return Attr[A_CDEF] + max(0, AttrAdj[A_DEF][BONUS_WEAPON]);
+              return Attr[A_CDEF] + max<int16_t>(0, AttrAdj[A_DEF][BONUS_WEAPON]);
           }
           return (StateFlags & MS_CASTING) ? Attr[A_CDEF] : Attr[A_DEF];
       }
@@ -426,7 +426,7 @@ class Creature: public Thing, public Magic
       virtual uint16 getSpellFlags(rID spID) // horrid kludge used for counterspells
          { return CasterLev() >= SAL(TEFF(spID)->Level) ? SP_KNOWN : 0; }
       virtual int16 CasterLev()
-        { return max(ChallengeRating(),1); }
+        { return max<int16_t>(ChallengeRating(),1); }
       virtual uint32 MMFeats(uint32 sp) { return 0; }
       virtual void getBuffInfo(int16 *pBuffCount, int16 *pManaCost, rID **pBuffList);
       virtual bool isSpecialistIn(uint32 School);
@@ -729,7 +729,7 @@ class Character: public Creature
       int8 WepSkill(Item * it) ;
       virtual int16 LevelAs(rID cID);
       rID GetRaceID() { return RaceID; }
-      rID GetClassID(int16 cl) { return ClassID[max(0,min(cl,2))]; }
+      rID GetClassID(int16 cl) { return ClassID[max<int>(0,min<int>(cl,2))]; }
       int16 TotalLevel() { return Level[0] + Level[1] + Level[2]; }
       virtual int16 CasterLev();
       int16 PsionicLev() { return Abilities[CA_PSIONICS]; }
@@ -802,7 +802,7 @@ class Character: public Creature
       int16 getGodAnger(rID gID) /* HACKFIX */
         { int16 ang = Anger[theGame->GodNum(gID)];
           ang -= (int16)TGOD(gID)->GetConst(TOLERANCE_VAL);
-          return max(0,ang); }
+          return max<int16_t>(0,ang); }
       
 
     ARCHIVE_CLASS(Character,Creature,r)

--- a/inc/Creature.h
+++ b/inc/Creature.h
@@ -191,19 +191,19 @@ class Creature: public Thing, public Magic
     public:
       /* General Stuff */
 		  Creature(rID mID,int16 _Type);
-		  int32 cMana() { return max(0,(mMana+(GetAttr(A_MAN)*5)-(uMana+hMana))); }
+		  int32 cMana() { return std::max(0,(mMana+(GetAttr(A_MAN)*5)-(uMana+hMana))); }
 	    int32 tMana() { return mMana + GetAttr(A_MAN)*5; }
       void  LoseMana(int32 amt, bool hold=false)
         { if (hold)
             hMana += amt;
           else
-            uMana = min(tMana() - hMana,uMana + amt); }
+            uMana = std::min(tMana() - hMana,uMana + amt); }
       void GainMana(int32 amt)
-        { uMana = max(0,uMana - amt); } 
+        { uMana = std::max(0,uMana - amt); }
       bool hasMana(int32 amt)
         { return cMana() > amt; }
       int32 nhMana()
-        { return max(0,tMana() - hMana); }
+        { return std::max(0,tMana() - hMana); }
       void GainStatiFromBody(rID _mID);
       void GainStatiFromTemplate(rID _tID, bool turn_on);
       /* Use of an attribute can lead to gains. */
@@ -230,7 +230,7 @@ class Creature: public Thing, public Magic
       virtual int16 getDef() {
           if (StateFlags & MS_STILL_CAST) {
               CalcValues();
-              return Attr[A_CDEF] + max<int16_t>(0, AttrAdj[A_DEF][BONUS_WEAPON]);
+              return Attr[A_CDEF] + std::max<int16_t>(0, AttrAdj[A_DEF][BONUS_WEAPON]);
           }
           return (StateFlags & MS_CASTING) ? Attr[A_CDEF] : Attr[A_DEF];
       }
@@ -245,7 +245,7 @@ class Creature: public Thing, public Magic
 
       int32 MoveTimeout(int from_x, int from_y) {
         int32 Mov = MoveAttr(from_x,from_y);
-        int32 normal_timeout = max(1,1000 / max(Mov,1));
+        int32 normal_timeout = std::max(1,1000 / std::max(Mov,1));
         return normal_timeout;
       } 
 
@@ -389,7 +389,7 @@ class Creature: public Thing, public Magic
       virtual int16 SkillLevel(int16 n);
       virtual int16 ConcentBuffer() {
           int16 cc = SkillLevel(SK_CONCENT);
-          return max(cc-5,0);
+          return std::max(cc-5,0);
       }
       virtual int8 WepSkill(rID wep, bool ignore_str=false);
       int8 WepSkill(Item * it) ;
@@ -426,7 +426,7 @@ class Creature: public Thing, public Magic
       virtual uint16 getSpellFlags(rID spID) // horrid kludge used for counterspells
          { return CasterLev() >= SAL(TEFF(spID)->Level) ? SP_KNOWN : 0; }
       virtual int16 CasterLev()
-        { return max<int16_t>(ChallengeRating(),1); }
+        { return std::max<int16_t>(ChallengeRating(),1); }
       virtual uint32 MMFeats(uint32 sp) { return 0; }
       virtual void getBuffInfo(int16 *pBuffCount, int16 *pManaCost, rID **pBuffList);
       virtual bool isSpecialistIn(uint32 School);
@@ -560,7 +560,7 @@ class Creature: public Thing, public Magic
       bool okBondedMount(int16 lev, rID mID, rID tID);
 
       bool isFlatFooted()
-        { return FFCount > min(5,10+Mod(A_WIS)); }
+        { return FFCount > std::min(5,10+Mod(A_WIS)); }
       bool isFlanking(Creature *c);
       int8 BestHDType(); // ww: includes all types, templates, etc. 
       virtual int16 SpellDmgBonus(rID eID);
@@ -657,9 +657,9 @@ class Character: public Creature
       uint32 SpellKnown(int16 spNum) { return Spells[spNum]; }
       virtual void RecalcStaffSpells();
       virtual void RecalcCraftFormulas();
-      int32 kcMana() { return max(0,(mMana+(KAttr[A_MAN]*5)-(uMana+hMana))); }
+      int32 kcMana() { return std::max(0,(mMana+(KAttr[A_MAN]*5)-(uMana+hMana))); }
 	    int32 ktMana() { return mMana + KAttr[A_MAN]*5; }
-	    int16 UnspentSP(int16 cl) { return max(0,TotalSP[cl] - SpentSP[cl]); }
+	    int16 UnspentSP(int16 cl) { return std::max(0,TotalSP[cl] - SpentSP[cl]); }
 	    int16 UnspentCSP(rID clID) { for (int16 i=0;i!=6;i++)
 	                                  if (clID == ClassID[i])
 	                                    return UnspentSP(i);
@@ -668,7 +668,7 @@ class Character: public Creature
         {
           // ww: taking the Creature challenge rating ends up having
           // undesired effects with wild shaped druids
-          return // max(Creature::ChallengeRating()-1,0) + 
+          return // std::max(Creature::ChallengeRating()-1,0) +
             ((int16)(Level[0]+Level[1]+Level[2]));
         }
 	    EvReturn Event(EventInfo &ev);
@@ -729,7 +729,7 @@ class Character: public Creature
       int8 WepSkill(Item * it) ;
       virtual int16 LevelAs(rID cID);
       rID GetRaceID() { return RaceID; }
-      rID GetClassID(int16 cl) { return ClassID[max<int>(0,min<int>(cl,2))]; }
+      rID GetClassID(int16 cl) { return ClassID[std::max<int>(0, std::min<int>(cl,2))]; }
       int16 TotalLevel() { return Level[0] + Level[1] + Level[2]; }
       virtual int16 CasterLev();
       int16 PsionicLev() { return Abilities[CA_PSIONICS]; }
@@ -802,7 +802,7 @@ class Character: public Creature
       int16 getGodAnger(rID gID) /* HACKFIX */
         { int16 ang = Anger[theGame->GodNum(gID)];
           ang -= (int16)TGOD(gID)->GetConst(TOLERANCE_VAL);
-          return max<int16_t>(0,ang); }
+          return std::max<int16_t>(0,ang); }
       
 
     ARCHIVE_CLASS(Character,Creature,r)

--- a/inc/Defines.h
+++ b/inc/Defines.h
@@ -119,7 +119,7 @@ typedef signed long hObj;
 #define COPPER    4
 #define ELECTRUM  5
 
-#define SAL(a) (__SAL[min<int>((a),9)])
+#define SAL(a) (__SAL[std::min<int>((a),9)])
 
 /* These constants can appear in dice values rolled with the
    LRoll function. They allow level-based dice rolls. */
@@ -4636,11 +4636,6 @@ typedef signed long hObj;
 #define TC_WCHOICE   0xFF000007 // '60%'
 
 #define MAX_OVERLAY_GLYPHS 250
-
-#include <algorithm>
-
-using std::max;
-using std::min;
 
 class Object;
 class Map;

--- a/inc/Defines.h
+++ b/inc/Defines.h
@@ -119,7 +119,7 @@ typedef signed long hObj;
 #define COPPER    4
 #define ELECTRUM  5
 
-#define SAL(a) (__SAL[min((a),9)])
+#define SAL(a) (__SAL[min<int>((a),9)])
 
 /* These constants can appear in dice values rolled with the
    LRoll function. They allow level-based dice rolls. */
@@ -4637,12 +4637,10 @@ typedef signed long hObj;
 
 #define MAX_OVERLAY_GLYPHS 250
 
-#ifndef max
-#define max(a,b) (((a)>(b)) ? (a) : (b))
-#endif
-#ifndef min
-#define min(a,b) (((a)>(b)) ? (b) : (a))
-#endif
+#include <algorithm>
+
+using std::max;
+using std::min;
 
 class Object;
 class Map;

--- a/inc/Inline.h
+++ b/inc/Inline.h
@@ -79,10 +79,10 @@ inline int16 LevelAdjust(int16 val, int16 level, int16 spec=1)
         case LEVEL_2EVERY4: return ((level+3)/4)*2;  
         case LEVEL_2EVERY5: return ((level+4)/5)*2;  
 
-        case LEVEL_MAX5:    return min(5,level);  
-        case LEVEL_MAX10:   return min(10,level);  
-        case LEVEL_MAX15:   return min(15,level);  
-        case LEVEL_MAX20:   return min(20,level);  
+        case LEVEL_MAX5:    return min<int16_t>(5,level);
+        case LEVEL_MAX10:   return min<int16_t>(10,level);
+        case LEVEL_MAX15:   return min<int16_t>(15,level);
+        case LEVEL_MAX20:   return min<int16_t>(20,level);
 
         case LEVEL_SCALED:
           if (level <= 9)
@@ -118,9 +118,9 @@ inline int16 LevelAdjust(int16 val, int16 level, int16 spec=1)
         case PLUS_MINUS2: return max(spec-2,0);
         case PLUS_MINUS3: return max(spec-3,0);
 
-        case LEVEL_MIN3: return max(3,level);
-        case LEVEL_MIN5: return max(5,level);
-        case LEVEL_MIN10: return max(10,level);
+        case LEVEL_MIN3: return max<int16_t>(3,level);
+        case LEVEL_MIN5: return max<int16_t>(5,level);
+        case LEVEL_MIN10: return max<int16_t>(10,level);
 
         case PLUS_ADD1:  return spec+1;
         case PLUS_ADD2:  return spec+2;
@@ -684,7 +684,7 @@ inline int16 Thing::HighStatiMag(int16 n,int16 Val, Thing *t)
     StatiIterNature(this,n)
         if (S->Val == Val || Val == -1) 
           if (!t || S->h == t->myHandle)
-            m = max(m,S->Mag);
+            m = max<int16_t>(m,S->Mag);
     StatiIterEnd(this)
     return m; 
   }
@@ -714,7 +714,7 @@ inline int16 Thing::HighSourceCLev(uint8 src)
     int16 clev = 0;
     StatiIter(this)
       if (S->Source == src)
-        clev = max(0,clev);
+        clev = max<int16_t>(0,clev);
     StatiIterEnd(this)
     return clev;
   }

--- a/inc/Inline.h
+++ b/inc/Inline.h
@@ -34,6 +34,7 @@
     NOTE: What functions are and are not included in this file should be 
   SERIOUSLY reevaluated in the near future.
 */
+#include <algorithm>
 
 inline int16 random(int16 mx)
   {
@@ -79,10 +80,10 @@ inline int16 LevelAdjust(int16 val, int16 level, int16 spec=1)
         case LEVEL_2EVERY4: return ((level+3)/4)*2;  
         case LEVEL_2EVERY5: return ((level+4)/5)*2;  
 
-        case LEVEL_MAX5:    return min<int16_t>(5,level);
-        case LEVEL_MAX10:   return min<int16_t>(10,level);
-        case LEVEL_MAX15:   return min<int16_t>(15,level);
-        case LEVEL_MAX20:   return min<int16_t>(20,level);
+        case LEVEL_MAX5:    return std::min<int16_t>(5,level);
+        case LEVEL_MAX10:   return std::min<int16_t>(10,level);
+        case LEVEL_MAX15:   return std::min<int16_t>(15,level);
+        case LEVEL_MAX20:   return std::min<int16_t>(20,level);
 
         case LEVEL_SCALED:
           if (level <= 9)
@@ -115,12 +116,12 @@ inline int16 LevelAdjust(int16 val, int16 level, int16 spec=1)
         case PLUS_15PER1: return spec*15;
         case PLUS_20PER1: return spec*20;
 
-        case PLUS_MINUS2: return max(spec-2,0);
-        case PLUS_MINUS3: return max(spec-3,0);
+        case PLUS_MINUS2: return std::max(spec-2,0);
+        case PLUS_MINUS3: return std::max(spec-3,0);
 
-        case LEVEL_MIN3: return max<int16_t>(3,level);
-        case LEVEL_MIN5: return max<int16_t>(5,level);
-        case LEVEL_MIN10: return max<int16_t>(10,level);
+        case LEVEL_MIN3: return std::max<int16_t>(3,level);
+        case LEVEL_MIN5: return std::max<int16_t>(5,level);
+        case LEVEL_MIN10: return std::max<int16_t>(10,level);
 
         case PLUS_ADD1:  return spec+1;
         case PLUS_ADD2:  return spec+2;
@@ -570,7 +571,7 @@ inline void SetSilence()
   { Silence++; }
 
 inline void UnsetSilence()
-  { Silence = max(0,Silence-1); }
+  { Silence = std::max(0,Silence-1); }
 
 inline int16 MMFeatLevels(uint32 MM)
   {
@@ -684,7 +685,7 @@ inline int16 Thing::HighStatiMag(int16 n,int16 Val, Thing *t)
     StatiIterNature(this,n)
         if (S->Val == Val || Val == -1) 
           if (!t || S->h == t->myHandle)
-            m = max<int16_t>(m,S->Mag);
+            m = std::max<int16_t>(m,S->Mag);
     StatiIterEnd(this)
     return m; 
   }
@@ -714,7 +715,7 @@ inline int16 Thing::HighSourceCLev(uint8 src)
     int16 clev = 0;
     StatiIter(this)
       if (S->Source == src)
-        clev = max<int16_t>(0,clev);
+        clev = std::max<int16_t>(0,clev);
     StatiIterEnd(this)
     return clev;
   }

--- a/inc/Item.h
+++ b/inc/Item.h
@@ -126,7 +126,7 @@ class Item: public Thing, public Magic
       Item* TryStack(Item *i);
       Item* TryStack(Map *m, int16 x, int16 y);
       int16 MaxHP();
-      void  MendHP(int16 hp) { cHP = min(MaxHP(),cHP+hp); }
+      void  MendHP(int16 hp) { cHP = min<int16_t>(MaxHP(),cHP+hp); }
       int16 GetHP() { return cHP; }
       virtual bool operator==(Item &i);
 
@@ -144,7 +144,7 @@ class Item: public Thing, public Magic
           return 0;
           */
         else
-          return max(Plus,HighStatiMag(BOOST_PLUS));
+          return max<int16_t>(Plus,HighStatiMag(BOOST_PLUS));
       }
       int8 GetInherentPlus() { return Plus; }
       void SetInherentPlus(int8 i) { int32 dmg;

--- a/inc/Item.h
+++ b/inc/Item.h
@@ -126,7 +126,7 @@ class Item: public Thing, public Magic
       Item* TryStack(Item *i);
       Item* TryStack(Map *m, int16 x, int16 y);
       int16 MaxHP();
-      void  MendHP(int16 hp) { cHP = min<int16_t>(MaxHP(),cHP+hp); }
+      void  MendHP(int16 hp) { cHP = std::min<int16_t>(MaxHP(),cHP+hp); }
       int16 GetHP() { return cHP; }
       virtual bool operator==(Item &i);
 
@@ -144,7 +144,7 @@ class Item: public Thing, public Magic
           return 0;
           */
         else
-          return max<int16_t>(Plus,HighStatiMag(BOOST_PLUS));
+          return std::max<int16_t>(Plus,HighStatiMag(BOOST_PLUS));
       }
       int8 GetInherentPlus() { return Plus; }
       void SetInherentPlus(int8 i) { int32 dmg;

--- a/lang/Grammar.acc
+++ b/lang/Grammar.acc
@@ -495,7 +495,7 @@ attack_entry:                  { uint8 dt = AD_NORM; dam.Set(0,0,0);
                                  theMon->Attk[CurrAttk].DType = dt;
                                  /*
                                  if (at == A_ABIL)
-                                   theMon->Attk[CurrAttk].u.a.DC = max(
+                                   theMon->Attk[CurrAttk].u.a.DC = std::max(
                                         theMon->Attk[CurrAttk].u.a.DC, 1);
                                         */
                                  CurrAttk++;
@@ -904,7 +904,7 @@ domain_def: DOMAIN LITERAL<name> ':' cexpr3<type>
 
 domain_entry:
   { int8 sp = 0; }
-  SPELLS (':')? (res_ref<rr> { theDom->Spells[min(sp,8)] = rr; sp++; } (',')?)* ';'
+  SPELLS (':')? (res_ref<rr> { theDom->Spells[std::min<int>(sp,8)] = rr; sp++; } (',')?)* ';'
   { if (sp > 9) 
       { yyerror(Format("Error: Domain %s has %d spells; must have at most nine.",
         theModule->QTextSeg + theDom->Name,sp)); } }
@@ -923,7 +923,7 @@ god_def: GOD LITERAL<name>  { theRes = theGod; theGod->Name = name; }
 
 god_entry:
   { int8 dm = 0; }
-  DOMAINS (':')? (res_ref<rr> { theGod->Domains[min(dm,5)] = rr; dm++; } (',')?)* ';'
+  DOMAINS (':')? (res_ref<rr> { theGod->Domains[std::min<int>(dm,5)] = rr; dm++; } (',')?)* ';'
   { if (dm < 3 || dm > 6) 
       { yyerror(Format("Error: God %s has %d domains; must have between 3 and 6.",
         theModule->QTextSeg + theGod->Name,dm)); } }
@@ -1078,7 +1078,7 @@ temp_attack_entry:             { uint8 dt = AD_NORM; dam.Set(0,0,0);
                                  theTemp->NewAttk[CurrAttk].DType = dt;
                                  /*
                                  if (at == A_ABIL)
-                                   theTemp->NewAttk[CurrAttk].u.a.DC = max(
+                                   theTemp->NewAttk[CurrAttk].u.a.DC = std::max(
                                         theTemp->NewAttk[CurrAttk].u.a.DC, 1);
                                         */
                                  CurrAttk++;
@@ -2296,7 +2296,7 @@ param_list<%in pBSysFunc b, YYSTYPE fn %out VBlock bl, int narg>:
         if (PStorage[i] == RT_REGISTER)
           FreeRegister((int16)PValue[i]);
         }
-      *narg = max(*narg,b->ParamCount);
+      *narg = std::max<int>(*narg,b->ParamCount);
       Done:;
       }
             

--- a/src/Annot.cpp
+++ b/src/Annot.cpp
@@ -357,10 +357,10 @@ bool Resource::GetList(int16 ln, rID *lv,int16 max) {
 DoDefaults:
     switch(ln) {
     case RM_WEIGHTS: 
-        memcpy(lv,RM_Weights,min(max*sizeof(rID),sizeof(RM_Weights)));
+        memcpy(lv,RM_Weights,std::min(max*sizeof(rID),sizeof(RM_Weights)));
         return true;
     case RC_WEIGHTS:
-        memcpy(lv,RC_Weights,min(max*sizeof(rID),sizeof(RC_Weights)));
+        memcpy(lv,RC_Weights,std::min(max*sizeof(rID),sizeof(RC_Weights)));
         return true;
     case ROOM_WEIGHTS:
         for (q=0;q!=MAX_MODULES;q++)
@@ -425,7 +425,7 @@ DoDefaults:
         *lv++ = 0; *lv++ = 0; *lv++ = 0; 
         return true;
     default:
-        memcpy(lv,EmptyList,min(max*sizeof(rID),sizeof(EmptyList)));
+        memcpy(lv,EmptyList,std::min(max*sizeof(rID),sizeof(EmptyList)));
         return false;
     }
 }
@@ -730,7 +730,7 @@ void Resource::GrantGear(Creature *c, rID xID, bool doRanged)
                 // ww: if you play a super-lucky character, you will find
                 // that all of your opponents have powerful items
                 if (theGame->GetPlayer(0))
-                  luck = max<int>(luck,theGame->GetPlayer(0)->GetAttr(A_LUC));
+                  luck = std::max<int>(luck,theGame->GetPlayer(0)->GetAttr(A_LUC));
                 it = Item::GenItem(IG_MONEQUIP,iID,the_lev,luck,MonsterItems);
                 if (!it)
                   continue;

--- a/src/Annot.cpp
+++ b/src/Annot.cpp
@@ -730,7 +730,7 @@ void Resource::GrantGear(Creature *c, rID xID, bool doRanged)
                 // ww: if you play a super-lucky character, you will find
                 // that all of your opponents have powerful items
                 if (theGame->GetPlayer(0))
-                  luck = max(luck,theGame->GetPlayer(0)->GetAttr(A_LUC));
+                  luck = max<int>(luck,theGame->GetPlayer(0)->GetAttr(A_LUC));
                 it = Item::GenItem(IG_MONEQUIP,iID,the_lev,luck,MonsterItems);
                 if (!it)
                   continue;

--- a/src/Base.cpp
+++ b/src/Base.cpp
@@ -449,7 +449,7 @@ void* x_realloc(void *block, size_t unit, size_t sz, size_t osz)
     void *vp;
     vp = malloc(sz*unit);
     memset(vp,0,sz*unit);
-    memcpy(vp,block,min(sz,osz)*unit);
+    memcpy(vp,block,std::min(sz,osz)*unit);
     free(block);
     return vp;
   }
@@ -546,9 +546,9 @@ template<class S,int32 Initial,int32 Delta>
 		if (Count+Delta+10 < Size)
 			return;
     if (!Items) {
-      Items = (S*) malloc(max(Initial,Delta)*sizeof(S));
-      memset(Items,0,max(Initial,Delta)*sizeof(S));
-      Size = max(Initial,Delta);
+      Items = (S*) malloc(std::max(Initial,Delta)*sizeof(S));
+      memset(Items,0, std::max(Initial,Delta)*sizeof(S));
+      Size = std::max(Initial,Delta);
       return;
       }
     Items = (S*) x_realloc(Items,sizeof(S),Size+Delta,Size);
@@ -577,7 +577,7 @@ template<class S,int32 Initial, int32 Delta>
     ASSERT(idx >= 0)
     while(Size <= idx+1)
       Enlarge();
-    Count = max(Count,idx+1);
+    Count = std::max(Count,idx+1);
     Items[I(idx,Size)] = s;
     if (Count)
       Items[0] = Items[0];
@@ -631,9 +631,9 @@ int16 Dice::Roll()
     else
       n+=Bonus;
     if (Number > 0)
-		  return max(n,0);
+		  return std::max(n,0);
     else if (Number < 0)
-      return min(n,0);
+      return std::min(n,0);
     else
       return n;
 	}
@@ -647,7 +647,7 @@ int16 Dice::Roll(int8 Number, int8 Sides, int8 Bonus,int8 e)
 		for(i=0;i!=Number;i++)
 			n+=(random(Sides)+1);
 		n+=Bonus;
-		return max(n,0);
+		return std::max(n,0);
 	}
 
 

--- a/src/Create.cpp
+++ b/src/Create.cpp
@@ -1115,7 +1115,7 @@ void CreatePerk(PerkSet& Perks, int i, PerkType type, Player *p)
                     */
                     // redo = 1;
 
-                    it->SetInherentPlus(min(3,it->GetInherentPlus()));
+                    it->SetInherentPlus(min<int8_t>(3,it->GetInherentPlus()));
 
                     while ((!it->eID) && it->ItemLevel() <= 5 &&
                         it->GetPlus() < 5)
@@ -1847,7 +1847,7 @@ void Character::GainXP(uint32 _XP)
 
     _XP -= (((int32)_XP) * XPPenalty()) / 100;
 
-    XP += max(0,_XP);
+    XP += max<int>(0,_XP);
     xpTicks++;
     for (i=0;i!=MAX_GODS;i++)
         if (PrayerTimeout[i])
@@ -1977,7 +1977,7 @@ void Character::KillXP(Creature *kill, int16 percent)
     int16 ECL;
     ECL = ChallengeRating();
     if (HasStati(POLYMORPH))
-        ECL += max(0,TMON(mID)->CR);
+        ECL += max<int16_t>(0,TMON(mID)->CR);
     s = kill->ChallengeRating() - ECL;
     if (s > 10)
         s = 10;
@@ -1985,7 +1985,7 @@ void Character::KillXP(Creature *kill, int16 percent)
         s = -9;
     nXP = (nXP * Scale[s+9]) / 100;
 
-    nXP = (nXP * 100) / SlowAdvance[min(ChallengeRating(),6)];
+    nXP = (nXP * 100) / SlowAdvance[min<int>(ChallengeRating(),6)];
 
     if (kill->HasStati(WAS_FRIENDLY,-1,this))
         nXP /= 3;
@@ -2127,7 +2127,7 @@ void Creature::ThiefXP(rID regID)
     if (foundTreasure && foundMon) {
         IDPrint("You slip out like a thief in the night!", "The <Obj> slips out like a thief in the night!",this);
         percent = (AbilityLevel(CA_THIEF_IN_THE_NIGHT) * 
-            100) / max(1,ChallengeRating());
+            100) / max<int>(1,ChallengeRating());
         for (i=0;i!=mc;i++)
             KillXP(ml[i],percent);
     }
@@ -2958,7 +2958,7 @@ void Player::GainAbility(int16 ab, uint32 pa, rID sourceID, int16 statiSource) {
     int16 i,j;
 
     if (ab != CA_SMITE)
-        pa = max(pa,1);
+        pa = max(pa,1u);
 
     switch (ab) {
     case CA_AURA_OF_VALOUR:
@@ -3423,7 +3423,7 @@ int8 Character::WepSkill(rID wID, bool ignore_str)
 
     StatiIterNature(this,WEP_SKILL)
         if (S->eID == wID)
-            best = max(best,S->Val);
+            best = max<int8_t>(best,S->Val);
     StatiIterEnd(this)
         if (best) return best; 
     if (wID == 0) return WS_NOT_PROF; 
@@ -3557,14 +3557,14 @@ int16 Character::MaxRanks(int16 sk)
     mr += ClassLevelRanks[lv];
 
     if (isFamiliar(sk))
-        mr = max(mr,min(TotalLevel(),5));
+        mr = max<int>(mr,min<int>(TotalLevel(),5));
 
     /* Each Intensive Study (Sneak Attack & Stealth) increases
     your maximum Hide and Move Silently ranks by 2, up to a
     maximum of what a rogue of your character level would have. */
     if (sk == SK_HIDE || sk == SK_MOVE_SIL)
         if (mr < ClassLevelRanks[TotalLevel()])
-            mr = min(mr + IntStudy[STUDY_SNEAK]*2,
+            mr = min<int>(mr + IntStudy[STUDY_SNEAK]*2,
             ClassLevelRanks[TotalLevel()]);
 
     StatiIter(this)
@@ -3613,7 +3613,7 @@ bool Character::HasSkill(int16 sk, bool check_allies)
 
 int16 Character::LevelAs(rID cl)
 {
-    if (ClassID[0] == cl) return max(1,Level[0]);
+    if (ClassID[0] == cl) return max<int>(1,Level[0]);
     if (ClassID[1] == cl) return Level[1];
     if (ClassID[2] == cl) return Level[2];
     return 0;
@@ -3631,7 +3631,7 @@ int16 Character::CasterLev()
     int16 ab = AbilityLevel(CA_SPELLCASTING);
     /* Hack for 1st level bards */
     if (HasStati(BONUS_SLOTS))
-        ab = max(ab,1);
+        ab = max<int>(ab,1);
     return ab;
 }
 
@@ -3742,7 +3742,7 @@ int16 Creature::SkillLevel(int16 sk)
         if (HasStati(ANC_MEM,sk))
         {
             int16 mr = thisp->MaxRanks(sk);
-            s_ins = max(s_ins,4 - abs(mr-sr));
+            s_ins = max<int>(s_ins,4 - abs(mr-sr));
             sr = mr;
         }
         if (thisp->RaceID)
@@ -3758,11 +3758,11 @@ int16 Creature::SkillLevel(int16 sk)
     }
     else if (HasFeat(sk)) {
         // assume monsters get Level+3 for class skills like we do!
-        sr = max(1,ChallengeRating()) + 3;
+        sr = max<int>(1,ChallengeRating()) + 3;
         for (i=0;Synergies[i][0];i++)
             if (Synergies[i][0] == sk)
                 if (HasFeat(Synergies[i][1]))
-                    s_syn += (max(1,ChallengeRating())+3) /
+                    s_syn += (max<int>(1,ChallengeRating())+3) /
                     Synergies[i][2];
         TMonster *tm = TMON(tmID);
         TTemplate *tt;
@@ -3795,24 +3795,24 @@ FoundFocus:
         if (S->Val == sk || S->Val == -1)
             switch (S->Source) {
           case SS_CLAS:
-              s_feat = max(s_feat,S->Mag);
+              s_feat = max<int>(s_feat,S->Mag);
               break;
           case SS_BODY:
           case SS_TMPL:
           case SS_RACE:
-              s_racial = max(s_racial,S->Mag);
+              s_racial = max<int>(s_racial,S->Mag);
               break;
           case SS_DOMA:
-              s_domain = max(s_domain,S->Mag);
+              s_domain = max<int>(s_domain,S->Mag);
               break;
           case SS_ITEM:
-              s_item = max(s_item,S->Mag);
+              s_item = max<int>(s_item,S->Mag);
               break;
           case SS_PERM:
-              s_focus = max(s_focus,S->Mag);
+              s_focus = max<int>(s_focus,S->Mag);
               break;
           default:
-              s_enhance = max(s_enhance,S->Mag);
+              s_enhance = max<int>(s_enhance,S->Mag);
               break;
         }
         StatiIterEnd(this)
@@ -3942,16 +3942,16 @@ int8 Creature::rateMeleeWeapon() {
                 continue;
             if (it->isGroup(WG_THROWN))
                 continue;
-            rating = max(1,rating);
+            rating = max<int>(1,rating);
             if (!it->isGroup(WG_SIMPLE) &&
                 !it->isGroup(WG_DAGGERS) &&
                 !it->isGroup(WG_LIGHT) &&
                 stricmp("knife",NAME(it->iID)) &&
                 (stricmp("short sword",NAME(it->iID))
                 || isSmallRace()))
-                rating = max(2,rating);
+                rating = max<int>(2,rating);
             if (WepSkill(it->iID) >= WS_FOCUSED)
-                rating = max(3,rating);
+                rating = max<int>(3,rating);
         }
         return rating;
 }
@@ -3962,13 +3962,13 @@ int8 Creature::rateRangedWeapon()
     for (it=FirstInv();it;it=NextInv())
         if (it->isType(T_BOW))
         {
-            rating = max(1,rating);
+            rating = max<int>(1,rating);
             if (it->iID == FIND("cranquin") ||
                 it->iID == FIND("long bow") ||
                 it->iID == FIND("composite long bow"))
-                rating = max(2,rating);
+                rating = max<int>(2,rating);
             if (WepSkill(it->iID) >= WS_FOCUSED)
-                rating = max(3,rating);
+                rating = max<int>(3,rating);
         }
         return rating;
 }  
@@ -4076,7 +4076,7 @@ LearnableSpell* Character::CalcSpellAccess() {
     if (ls[k].spID == sp)                     \
     if (ls[k].Type == typ)                  \
         {                                     \
-    ls[k].Level = min(ls[k].Level,lv);  \
+    ls[k].Level = min<int>(ls[k].Level,lv);  \
     added = true;                       \
         }                                     \
     if (!added) {                               \
@@ -4244,7 +4244,7 @@ void Player::LearnSpell(bool left) {
         /* Do we have the chart level to even consider this
         spell as an option? */
         if ((SAL(ls[i].Level) > AbilityLevel(CA_SPELLCASTING))
-            && !HasStati(BONUS_SLOTS,min(9,max(1,ls[i].Level))))
+            && !HasStati(BONUS_SLOTS,min(9,max<int>(1,ls[i].Level))))
             continue;
 
         /* Can't learn a spell you've already learned */

--- a/src/Create.cpp
+++ b/src/Create.cpp
@@ -843,7 +843,7 @@ bool Player::Reincarnate()
     Create(true);
 
     Named += " ";
-    Named += RomanNumerals[min(10,RInf.Count+2)];
+    Named += RomanNumerals[std::min(10,RInf.Count+2)];
 
 
     return true;
@@ -1115,7 +1115,7 @@ void CreatePerk(PerkSet& Perks, int i, PerkType type, Player *p)
                     */
                     // redo = 1;
 
-                    it->SetInherentPlus(min<int8_t>(3,it->GetInherentPlus()));
+                    it->SetInherentPlus(std::min<int8_t>(3,it->GetInherentPlus()));
 
                     while ((!it->eID) && it->ItemLevel() <= 5 &&
                         it->GetPlus() < 5)
@@ -1847,7 +1847,7 @@ void Character::GainXP(uint32 _XP)
 
     _XP -= (((int32)_XP) * XPPenalty()) / 100;
 
-    XP += max<int>(0,_XP);
+    XP += std::max<int>(0,_XP);
     xpTicks++;
     for (i=0;i!=MAX_GODS;i++)
         if (PrayerTimeout[i])
@@ -1918,7 +1918,7 @@ void Character::GainXP(uint32 _XP)
 
 void Character::LoseXP(uint32 _XP)
 {
-    XP = max(0,(int32)XP - (int32)_XP);
+    XP = std::max(0,(int32)XP - (int32)_XP);
     if (isPlayer())
         thisp->statiChanged = true;
 }
@@ -1977,7 +1977,7 @@ void Character::KillXP(Creature *kill, int16 percent)
     int16 ECL;
     ECL = ChallengeRating();
     if (HasStati(POLYMORPH))
-        ECL += max<int16_t>(0,TMON(mID)->CR);
+        ECL += std::max<int16_t>(0,TMON(mID)->CR);
     s = kill->ChallengeRating() - ECL;
     if (s > 10)
         s = 10;
@@ -1985,7 +1985,7 @@ void Character::KillXP(Creature *kill, int16 percent)
         s = -9;
     nXP = (nXP * Scale[s+9]) / 100;
 
-    nXP = (nXP * 100) / SlowAdvance[min<int>(ChallengeRating(),6)];
+    nXP = (nXP * 100) / SlowAdvance[std::min<int>(ChallengeRating(),6)];
 
     if (kill->HasStati(WAS_FRIENDLY,-1,this))
         nXP /= 3;
@@ -2127,7 +2127,7 @@ void Creature::ThiefXP(rID regID)
     if (foundTreasure && foundMon) {
         IDPrint("You slip out like a thief in the night!", "The <Obj> slips out like a thief in the night!",this);
         percent = (AbilityLevel(CA_THIEF_IN_THE_NIGHT) * 
-            100) / max<int>(1,ChallengeRating());
+            100) / std::max<int>(1,ChallengeRating());
         for (i=0;i!=mc;i++)
             KillXP(ml[i],percent);
     }
@@ -2398,19 +2398,19 @@ GodIsOkay:;
       case 1: /* half */ hpRolls[c][Level[c]-1] = (int8)(HD / 2); break; 
       case 2: /* full */ hpRolls[c][Level[c]-1] = (int8)HD ; break; 
       default: /* no */
-          hpRolls[c][Level[c]-1] = max(random(HD)+1,(HD/2));
+          hpRolls[c][Level[c]-1] = std::max(random(HD)+1,(HD/2));
     }
 
     switch (Opt(OPT_MAX_MANA)) {
       case 1: /* half */ manaRolls[c][Level[c]-1] = tc->ManaDie / 2; break;
       case 2: /* full */ manaRolls[c][Level[c]-1] = tc->ManaDie; break;
       default: /* no */
-          manaRolls[c][Level[c]-1] = max(random(tc->ManaDie)+1,(tc->ManaDie/2));
+          manaRolls[c][Level[c]-1] = std::max(random(tc->ManaDie)+1,(tc->ManaDie/2));
     } 
 
     for (i=0;GodIDList[i];i++)
         if (j = (int16)TGOD(GodIDList[i])->GetConst(LEVEL_BLEEDOFF))
-            FavPenalty[theGame->GodNum(GodIDList[i])] = max(0,FavPenalty[theGame->GodNum(GodIDList[i])] - j);
+            FavPenalty[theGame->GodNum(GodIDList[i])] = std::max(0,FavPenalty[theGame->GodNum(GodIDList[i])] - j);
 
     CalcValues();
 
@@ -2958,7 +2958,7 @@ void Player::GainAbility(int16 ab, uint32 pa, rID sourceID, int16 statiSource) {
     int16 i,j;
 
     if (ab != CA_SMITE)
-        pa = max(pa,1u);
+        pa = std::max(pa,1u);
 
     switch (ab) {
     case CA_AURA_OF_VALOUR:
@@ -2978,7 +2978,7 @@ void Player::GainAbility(int16 ab, uint32 pa, rID sourceID, int16 statiSource) {
                 SpellSlots[i]++;
         }
         if (Abilities[ab] == 1) // 1st level
-            BonusSlots[0] = BonusSpells[min(max(IAttr(A_INT)-9,0),21)][0];
+            BonusSlots[0] = BonusSpells[std::min(std::max(IAttr(A_INT)-9,0),21)][0];
         break;     
     case CA_DOMAINS:
         /* Learn the Spells */
@@ -3423,7 +3423,7 @@ int8 Character::WepSkill(rID wID, bool ignore_str)
 
     StatiIterNature(this,WEP_SKILL)
         if (S->eID == wID)
-            best = max<int8_t>(best,S->Val);
+            best = std::max<int8_t>(best,S->Val);
     StatiIterEnd(this)
         if (best) return best; 
     if (wID == 0) return WS_NOT_PROF; 
@@ -3557,14 +3557,14 @@ int16 Character::MaxRanks(int16 sk)
     mr += ClassLevelRanks[lv];
 
     if (isFamiliar(sk))
-        mr = max<int>(mr,min<int>(TotalLevel(),5));
+        mr = std::max<int>(mr,std::min<int>(TotalLevel(),5));
 
     /* Each Intensive Study (Sneak Attack & Stealth) increases
     your maximum Hide and Move Silently ranks by 2, up to a
     maximum of what a rogue of your character level would have. */
     if (sk == SK_HIDE || sk == SK_MOVE_SIL)
         if (mr < ClassLevelRanks[TotalLevel()])
-            mr = min<int>(mr + IntStudy[STUDY_SNEAK]*2,
+            mr = std::min<int>(mr + IntStudy[STUDY_SNEAK]*2,
             ClassLevelRanks[TotalLevel()]);
 
     StatiIter(this)
@@ -3613,7 +3613,7 @@ bool Character::HasSkill(int16 sk, bool check_allies)
 
 int16 Character::LevelAs(rID cl)
 {
-    if (ClassID[0] == cl) return max<int>(1,Level[0]);
+    if (ClassID[0] == cl) return std::max<int>(1,Level[0]);
     if (ClassID[1] == cl) return Level[1];
     if (ClassID[2] == cl) return Level[2];
     return 0;
@@ -3631,7 +3631,7 @@ int16 Character::CasterLev()
     int16 ab = AbilityLevel(CA_SPELLCASTING);
     /* Hack for 1st level bards */
     if (HasStati(BONUS_SLOTS))
-        ab = max<int>(ab,1);
+        ab = std::max<int>(ab,1);
     return ab;
 }
 
@@ -3742,7 +3742,7 @@ int16 Creature::SkillLevel(int16 sk)
         if (HasStati(ANC_MEM,sk))
         {
             int16 mr = thisp->MaxRanks(sk);
-            s_ins = max<int>(s_ins,4 - abs(mr-sr));
+            s_ins = std::max<int>(s_ins,4 - abs(mr-sr));
             sr = mr;
         }
         if (thisp->RaceID)
@@ -3758,11 +3758,11 @@ int16 Creature::SkillLevel(int16 sk)
     }
     else if (HasFeat(sk)) {
         // assume monsters get Level+3 for class skills like we do!
-        sr = max<int>(1,ChallengeRating()) + 3;
+        sr = std::max<int>(1,ChallengeRating()) + 3;
         for (i=0;Synergies[i][0];i++)
             if (Synergies[i][0] == sk)
                 if (HasFeat(Synergies[i][1]))
-                    s_syn += (max<int>(1,ChallengeRating())+3) /
+                    s_syn += (std::max<int>(1,ChallengeRating())+3) /
                     Synergies[i][2];
         TMonster *tm = TMON(tmID);
         TTemplate *tt;
@@ -3795,24 +3795,24 @@ FoundFocus:
         if (S->Val == sk || S->Val == -1)
             switch (S->Source) {
           case SS_CLAS:
-              s_feat = max<int>(s_feat,S->Mag);
+              s_feat = std::max<int>(s_feat,S->Mag);
               break;
           case SS_BODY:
           case SS_TMPL:
           case SS_RACE:
-              s_racial = max<int>(s_racial,S->Mag);
+              s_racial = std::max<int>(s_racial,S->Mag);
               break;
           case SS_DOMA:
-              s_domain = max<int>(s_domain,S->Mag);
+              s_domain = std::max<int>(s_domain,S->Mag);
               break;
           case SS_ITEM:
-              s_item = max<int>(s_item,S->Mag);
+              s_item = std::max<int>(s_item,S->Mag);
               break;
           case SS_PERM:
-              s_focus = max<int>(s_focus,S->Mag);
+              s_focus = std::max<int>(s_focus,S->Mag);
               break;
           default:
-              s_enhance = max<int>(s_enhance,S->Mag);
+              s_enhance = std::max<int>(s_enhance,S->Mag);
               break;
         }
         StatiIterEnd(this)
@@ -3942,16 +3942,16 @@ int8 Creature::rateMeleeWeapon() {
                 continue;
             if (it->isGroup(WG_THROWN))
                 continue;
-            rating = max<int>(1,rating);
+            rating = std::max<int>(1,rating);
             if (!it->isGroup(WG_SIMPLE) &&
                 !it->isGroup(WG_DAGGERS) &&
                 !it->isGroup(WG_LIGHT) &&
                 stricmp("knife",NAME(it->iID)) &&
                 (stricmp("short sword",NAME(it->iID))
                 || isSmallRace()))
-                rating = max<int>(2,rating);
+                rating = std::max<int>(2,rating);
             if (WepSkill(it->iID) >= WS_FOCUSED)
-                rating = max<int>(3,rating);
+                rating = std::max<int>(3,rating);
         }
         return rating;
 }
@@ -3962,13 +3962,13 @@ int8 Creature::rateRangedWeapon()
     for (it=FirstInv();it;it=NextInv())
         if (it->isType(T_BOW))
         {
-            rating = max<int>(1,rating);
+            rating = std::max<int>(1,rating);
             if (it->iID == FIND("cranquin") ||
                 it->iID == FIND("long bow") ||
                 it->iID == FIND("composite long bow"))
-                rating = max<int>(2,rating);
+                rating = std::max<int>(2,rating);
             if (WepSkill(it->iID) >= WS_FOCUSED)
-                rating = max<int>(3,rating);
+                rating = std::max<int>(3,rating);
         }
         return rating;
 }  
@@ -4076,7 +4076,7 @@ LearnableSpell* Character::CalcSpellAccess() {
     if (ls[k].spID == sp)                     \
     if (ls[k].Type == typ)                  \
         {                                     \
-    ls[k].Level = min<int>(ls[k].Level,lv);  \
+    ls[k].Level = std::min<int>(ls[k].Level,lv);  \
     added = true;                       \
         }                                     \
     if (!added) {                               \
@@ -4244,7 +4244,7 @@ void Player::LearnSpell(bool left) {
         /* Do we have the chart level to even consider this
         spell as an option? */
         if ((SAL(ls[i].Level) > AbilityLevel(CA_SPELLCASTING))
-            && !HasStati(BONUS_SLOTS,min(9,max<int>(1,ls[i].Level))))
+            && !HasStati(BONUS_SLOTS,std::min(9,std::max<int>(1,ls[i].Level))))
             continue;
 
         /* Can't learn a spell you've already learned */

--- a/src/Creature.cpp
+++ b/src/Creature.cpp
@@ -462,8 +462,8 @@ void Creature::Multiply(int16 val, bool split, bool msg)
         // ww: we had forgotten this important call ...
         mn->Initialize(true);
 
-        mn->mHP = max(1,mHP / (split ? 2 : 1));
-        mn->cHP = max(1,mHP / (split ? 2 : 1));        
+        mn->mHP = std::max(1,mHP / (split ? 2 : 1));
+        mn->cHP = std::max(1,mHP / (split ? 2 : 1));
       }
     if (!msg)
       ;
@@ -778,7 +778,7 @@ EvReturn Creature::Event(EventInfo &e) {
         * -- certainly in character for priests of pain! */
         if (HasAbility(CA_FEED_UPON_PAIN))
             if ((e.aDmg + e.xDmg)> 10 && cHP < mHP + Attr[A_THP])
-                cHP = min(mHP + Attr[A_THP],cHP + (e.aDmg + e.xDmg) / 10);
+                cHP = std::min(mHP + Attr[A_THP],cHP + (e.aDmg + e.xDmg) / 10);
 
         break;
     case EV_HIT:
@@ -1252,7 +1252,7 @@ void Creature::DoTurn() {
 
     /* This should really be the saving throw DC of the effect,
     but that's a lot of extra work, so for now... */
-    if (HasStati(PARALYSIS) && max(SkillLevel(SK_CONCENT),SkillLevel(SK_ESCAPE_ART)) >= 15)
+    if (HasStati(PARALYSIS) && std::max(SkillLevel(SK_CONCENT),SkillLevel(SK_ESCAPE_ART)) >= 15)
         if (SavingThrow(FORT,18,SA_MAGIC|SA_PARA)) {
             IPrint("You break the paralysis with Concentration!");
             RemoveStati(PARALYSIS);
@@ -1300,7 +1300,7 @@ void Creature::DoTurn() {
 
         if (HasSkill(SK_ESCAPE_ART))
             if (!(HasStati(PARALYSIS) || HasStati(AFRAID) || HasStati(STUNNED) || HasStati(ASLEEP)))
-                if (SkillCheck(SK_ESCAPE_ART, max(10 + cr->ChallengeRating()*2, 10 + cr->GetAttr(A_STR) ),true,false)) {
+                if (SkillCheck(SK_ESCAPE_ART, std::max(10 + cr->ChallengeRating()*2, 10 + cr->GetAttr(A_STR) ),true,false)) {
                     // better messages later
                     IPrint("You escape the <Obj>!",cr);
                     cr->DropEngulfed(this);
@@ -1481,7 +1481,7 @@ DoIntervention:
                 between sacrificing sapients for penance and being drained
                 by an increasingly angry Xel until she dies. */ 
                 if (isAnger && (gID != thisp->GodID)) {
-                    thisp->Anger[gNum] = max(0, thisp->Anger[gNum] - 2);
+                    thisp->Anger[gNum] = std::max(0, thisp->Anger[gNum] - 2);
                     if (!thisp->Anger[gNum])
                         thisp->GodMessage(gID,MSG_EXPENDED);
                 }
@@ -1519,7 +1519,7 @@ NoIntervention:;
         } else  FFCount = 30;
     } 
 
-    AoO = HasFeat(FT_COMBAT_REFLEXES) ? max(1,1 + Mod2(A_DEX)) : 1;
+    AoO = HasFeat(FT_COMBAT_REFLEXES) ? std::max(1,1 + Mod2(A_DEX)) : 1;
     if (HasFeat(FT_MOBILITY))
         AoO++; 
     if (HasAttk(A_GAZE))
@@ -1531,7 +1531,7 @@ NoIntervention:;
         // ww: currently the monster AI is not smart enough to conserve mana,
         // so monster mages almost always run out of it fighting each other
         // before you arrive ...
-        if (!isPlayer() || cMana() >= ((nhMana()*min(35+SkillLevel(SK_CONCENT)*2,80))/100)) {
+        if (!isPlayer() || cMana() >= ((nhMana()* std::min(35+SkillLevel(SK_CONCENT)*2,80))/100)) {
             /* 
             * Before it took about 60 turns to get 1 point back if you were
             * down one, and 60X turns if you were down X points. 
@@ -1555,8 +1555,8 @@ NoIntervention:;
             } else {
                 uMana--; 
                 // if you are down 5*N%, it takes you N turns to get back 1%
-                int N = (tMana() - (cMana() + hMana)) * 20 / max(1,tMana());
-                ManaPulse = N * 100 / max(1,tMana()); 
+                int N = (tMana() - (cMana() + hMana)) * 20 / std::max(1,tMana());
+                ManaPulse = N * 100 / std::max(1,tMana());
             } 
         } 
     }
@@ -1676,7 +1676,7 @@ NoIntervention:;
     StatiIterNature(this,REGEN)
         if (cHP < mHP+Attr[A_THP])
             if (S->Mag > random(100))
-                cHP = min(mHP+Attr[A_THP],cHP + max(1,GetStati(REGEN)->Mag/100));
+                cHP = std::min(mHP+Attr[A_THP],cHP + std::max(1,GetStati(REGEN)->Mag/100));
     StatiIterEnd(this)
 
     StatiIterNature(this,PERIODIC)
@@ -1705,7 +1705,7 @@ NoIntervention:;
         // ww: constant regeneration makes you hungry!
         int old_cHP = cHP;
         if (AbilityLevel(CA_REGEN) > 0) { 
-            cHP = min(mHP+Attr[A_THP],cHP+AbilityLevel(CA_REGEN));
+            cHP = std::min(mHP+Attr[A_THP],cHP+AbilityLevel(CA_REGEN));
 
             if (old_cHP < cHP) {
                 int curHunger = GetStatiDur(HUNGER);
@@ -1779,9 +1779,9 @@ void Creature::GetHungrier(int16 amt)
           hunger_val -= amt;
       }
     else
-      hunger_val -= max((amt*fast_percent)/100,1);
+      hunger_val -= std::max((amt*fast_percent)/100,1);
     
-    hunger_val = max<int>(0,hunger_val);
+    hunger_val = std::max<int>(0,hunger_val);
     
     SetStatiDur(HUNGER,-1,NULL,hunger_val);
   }
@@ -1861,9 +1861,9 @@ void Creature::GainInherentBonus(int16 at, int16 mag, bool msg)
       }
 
     if (HasStati(ADJUST_INH,at))
-      SetStatiMag(ADJUST_INH,at,NULL,min<int>(MaxBonus,CurrBonus+mag));
+      SetStatiMag(ADJUST_INH,at,NULL,std::min<int>(MaxBonus,CurrBonus+mag));
     else
-      GainPermStati(ADJUST_INH,NULL,SS_MISC,at,min(MaxBonus,mag),0);
+      GainPermStati(ADJUST_INH,NULL,SS_MISC,at,std::min(MaxBonus,mag),0);
 
     if (msg) switch (at) {
       case A_STR: IPrint("You feel stronger."); break;
@@ -2014,7 +2014,7 @@ int16 Creature::ChallengeRating(bool allow_neg)
     
     if (allow_neg)
       return CR;
-    return max<int>(0,CR);
+    return std::max<int>(0,CR);
   }
 
 
@@ -2024,7 +2024,7 @@ uint16 Creature::SightRange()
   {
     uint16 sr;
 
-    sr = max(3,4 + Mod(A_WIS));
+    sr = std::max(3,4 + Mod(A_WIS));
     if (HasAbility(CA_SHARP_SENSES))
       sr += AbilityLevel(CA_SHARP_SENSES);
 
@@ -2069,7 +2069,7 @@ bool Creature::LoseFatigue(int16 amt, bool avoid) {
 
     /* Hardcoded Essiah Fatigue Clause */
     if (avoid && cFP < 0 && isCharacter() && isThreatened() && isMType(MA_GOOD))
-        thisc->gainFavour(FIND("Essiah"), 25 * abs(cFP - min<int>(0, oFP)));
+        thisc->gainFavour(FIND("Essiah"), 25 * abs(cFP - std::min<int>(0, oFP)));
 
     if (cFP <= 0 && oFP > 0)
         stat_change = true;
@@ -2602,7 +2602,7 @@ TAttack* Creature::GetAttk(int8 typ)
       SacredAura.DType = AD_HOLY;
       SacredAura.u.a.DC = 0;
       SacredAura.u.a.Dmg.Set(
-        (int8)AbilityLevel(CA_SACRED_AURA),4,max<int8_t>(0,Mod(A_CHA)));
+        (int8)AbilityLevel(CA_SACRED_AURA),4,std::max<int8_t>(0,Mod(A_CHA)));
       //Fatal("ww: returning the address of a local stack variable");
       return &SacredAura;
       }
@@ -2791,26 +2791,26 @@ int16 Creature::AbilityLevel(int16 n)
       if (n == CA_SPELLCASTING)
         lv += thisp->IntStudy[STUDY_CASTING];
       if (n == CA_SNEAK_ATTACK)
-        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_SNEAK],
-              min(lv*2,((thisp->TotalLevel()*4+4)/10))));
+        lv = std::max<int>(lv,std::min(lv + thisp->IntStudy[STUDY_SNEAK],
+            std::min(lv*2,((thisp->TotalLevel()*4+4)/10))));
       if (n == CA_TURNING || n == CA_COMMAND)
-        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_TURNING]*2,
-              min(lv*2,((thisp->TotalLevel()*4+4)/5))));
+        lv = std::max<int>(lv,std::min(lv + thisp->IntStudy[STUDY_TURNING]*2,
+            std::min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_WILD_SHAPE)
-        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_SHAPES]*2,
-              min(lv*2,((thisp->TotalLevel()*4+4)/5))));
+        lv = std::max<int>(lv,std::min(lv + thisp->IntStudy[STUDY_SHAPES]*2,
+            std::min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_SACRED_MOUNT)
-        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_MOUNT]*3,
-              min(lv*2,((thisp->TotalLevel()*4+4)/5))));
+        lv = std::max<int>(lv,std::min(lv + thisp->IntStudy[STUDY_MOUNT]*3,
+            std::min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_SMITE)
-        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_SMITE]*4,
-              min(lv*2,((thisp->TotalLevel()*4+4)/5))));
+        lv = std::max<int>(lv,std::min(lv + thisp->IntStudy[STUDY_SMITE]*4,
+            std::min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_UNARMED_STRIKE || n == CA_STUN_ATTACK)
-        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_UNARMED]*2,
-              min(lv*2,((thisp->TotalLevel()*4+4)/5))));
+        lv = std::max<int>(lv,std::min(lv + thisp->IntStudy[STUDY_UNARMED]*2,
+            std::min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_LEGEND_LORE || n == CA_BARDIC_MUSIC || n == CA_STORYCRAFT)
-        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_BARDIC]*2,
-              min(lv*2,((thisp->TotalLevel()*4+4)/5))));
+        lv = std::max<int>(lv,std::min(lv + thisp->IntStudy[STUDY_BARDIC]*2,
+            std::min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       
         if (HasStati(POLYMORPH))
           if (n == CA_SPELLCASTING ||
@@ -2836,20 +2836,20 @@ int16 Creature::AbilityLevel(int16 n)
       StatiIterEnd(this)
       }
 
-    return max<int>(0,lv);
+    return std::max<int>(0,lv);
   }
 
 
 int16 Creature::Mod(int8 a)  { 
   int res = Attr[a] ? (Attr[a]-10)/2 : 0; 
   if (a == A_DEX && InSlot(SL_ARMOUR) && InSlot(SL_ARMOUR)->Type == T_ARMOUR) 
-    res = min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
+    res = std::min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
   return res;
 } 
 int16 Creature::Mod2(int8 a) { 
   int res = Attr[a] ? (Attr[a]-11)/2 : 0; 
   if (a == A_DEX && InSlot(SL_ARMOUR) && InSlot(SL_ARMOUR)->Type == T_ARMOUR) 
-    res = min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
+    res = std::min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
   return res;
 }
 
@@ -2859,13 +2859,13 @@ int16 Creature::KMod2(int8 a)  { return Mod2(a); }
 int16 Character::KMod(int8 a)  { 
   int res = Attr[a] ? (KAttr[a]-10)/2 : 0; 
   if (a == A_DEX && InSlot(SL_ARMOUR)) 
-    res = min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
+    res = std::min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
   return res;
 } 
 int16 Character::KMod2(int8 a) { 
   int res = Attr[a] ? (KAttr[a]-11)/2 : 0; 
   if (a == A_DEX && InSlot(SL_ARMOUR)) 
-    res = min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
+    res = std::min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
   return res;
 }
 
@@ -2978,11 +2978,11 @@ int32 Creature::ChargeBonus()
        * just started charging. 
        */
       
-      bonus = min(bonus,wep_hardness); 
+      bonus = std::min(bonus,wep_hardness);
       
-      bonus = max(0,min(10, bonus / 2)-1);
+      bonus = std::max(0,std::min(10, bonus / 2)-1);
       
-      return ChargeBonusTable[bonus][min<int>(29,GetStatiMag(CHARGING))];
+      return ChargeBonusTable[bonus][std::min<int>(29,GetStatiMag(CHARGING))];
 }
 
 bool Creature::canMoveThrough(EventInfo *e, int16 tx, int16 ty, 

--- a/src/Creature.cpp
+++ b/src/Creature.cpp
@@ -1781,7 +1781,7 @@ void Creature::GetHungrier(int16 amt)
     else
       hunger_val -= max((amt*fast_percent)/100,1);
     
-    hunger_val = max(0,hunger_val);
+    hunger_val = max<int>(0,hunger_val);
     
     SetStatiDur(HUNGER,-1,NULL,hunger_val);
   }
@@ -1861,7 +1861,7 @@ void Creature::GainInherentBonus(int16 at, int16 mag, bool msg)
       }
 
     if (HasStati(ADJUST_INH,at))
-      SetStatiMag(ADJUST_INH,at,NULL,min(MaxBonus,CurrBonus+mag));
+      SetStatiMag(ADJUST_INH,at,NULL,min<int>(MaxBonus,CurrBonus+mag));
     else
       GainPermStati(ADJUST_INH,NULL,SS_MISC,at,min(MaxBonus,mag),0);
 
@@ -2014,7 +2014,7 @@ int16 Creature::ChallengeRating(bool allow_neg)
     
     if (allow_neg)
       return CR;
-    return max(0,CR);
+    return max<int>(0,CR);
   }
 
 
@@ -2069,7 +2069,7 @@ bool Creature::LoseFatigue(int16 amt, bool avoid) {
 
     /* Hardcoded Essiah Fatigue Clause */
     if (avoid && cFP < 0 && isCharacter() && isThreatened() && isMType(MA_GOOD))
-        thisc->gainFavour(FIND("Essiah"), 25 * abs(cFP - min(0, oFP)));
+        thisc->gainFavour(FIND("Essiah"), 25 * abs(cFP - min<int>(0, oFP)));
 
     if (cFP <= 0 && oFP > 0)
         stat_change = true;
@@ -2602,7 +2602,7 @@ TAttack* Creature::GetAttk(int8 typ)
       SacredAura.DType = AD_HOLY;
       SacredAura.u.a.DC = 0;
       SacredAura.u.a.Dmg.Set(
-        (int8)AbilityLevel(CA_SACRED_AURA),4,(int8)max(0,Mod(A_CHA)));
+        (int8)AbilityLevel(CA_SACRED_AURA),4,max<int8_t>(0,Mod(A_CHA)));
       //Fatal("ww: returning the address of a local stack variable");
       return &SacredAura;
       }
@@ -2791,25 +2791,25 @@ int16 Creature::AbilityLevel(int16 n)
       if (n == CA_SPELLCASTING)
         lv += thisp->IntStudy[STUDY_CASTING];
       if (n == CA_SNEAK_ATTACK)
-        lv = max(lv,min(lv + thisp->IntStudy[STUDY_SNEAK],
+        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_SNEAK],
               min(lv*2,((thisp->TotalLevel()*4+4)/10))));
       if (n == CA_TURNING || n == CA_COMMAND)
-        lv = max(lv,min(lv + thisp->IntStudy[STUDY_TURNING]*2,
+        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_TURNING]*2,
               min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_WILD_SHAPE)
-        lv = max(lv,min(lv + thisp->IntStudy[STUDY_SHAPES]*2,
+        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_SHAPES]*2,
               min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_SACRED_MOUNT)
-        lv = max(lv,min(lv + thisp->IntStudy[STUDY_MOUNT]*3,
+        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_MOUNT]*3,
               min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_SMITE)
-        lv = max(lv,min(lv + thisp->IntStudy[STUDY_SMITE]*4,
+        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_SMITE]*4,
               min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_UNARMED_STRIKE || n == CA_STUN_ATTACK)
-        lv = max(lv,min(lv + thisp->IntStudy[STUDY_UNARMED]*2,
+        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_UNARMED]*2,
               min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       if (n == CA_LEGEND_LORE || n == CA_BARDIC_MUSIC || n == CA_STORYCRAFT)
-        lv = max(lv,min(lv + thisp->IntStudy[STUDY_BARDIC]*2,
+        lv = max<int>(lv,min(lv + thisp->IntStudy[STUDY_BARDIC]*2,
               min(lv*2,((thisp->TotalLevel()*4+4)/5))));
       
         if (HasStati(POLYMORPH))
@@ -2836,20 +2836,20 @@ int16 Creature::AbilityLevel(int16 n)
       StatiIterEnd(this)
       }
 
-    return max(0,lv);
+    return max<int>(0,lv);
   }
 
 
 int16 Creature::Mod(int8 a)  { 
   int res = Attr[a] ? (Attr[a]-10)/2 : 0; 
   if (a == A_DEX && InSlot(SL_ARMOUR) && InSlot(SL_ARMOUR)->Type == T_ARMOUR) 
-    res = min(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
+    res = min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
   return res;
 } 
 int16 Creature::Mod2(int8 a) { 
   int res = Attr[a] ? (Attr[a]-11)/2 : 0; 
   if (a == A_DEX && InSlot(SL_ARMOUR) && InSlot(SL_ARMOUR)->Type == T_ARMOUR) 
-    res = min(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
+    res = min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
   return res;
 }
 
@@ -2859,13 +2859,13 @@ int16 Creature::KMod2(int8 a)  { return Mod2(a); }
 int16 Character::KMod(int8 a)  { 
   int res = Attr[a] ? (KAttr[a]-10)/2 : 0; 
   if (a == A_DEX && InSlot(SL_ARMOUR)) 
-    res = min(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
+    res = min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
   return res;
 } 
 int16 Character::KMod2(int8 a) { 
   int res = Attr[a] ? (KAttr[a]-11)/2 : 0; 
   if (a == A_DEX && InSlot(SL_ARMOUR)) 
-    res = min(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
+    res = min<int>(res, ((Armour *)InSlot(SL_ARMOUR))->MaxDexBonus(this));
   return res;
 }
 
@@ -2982,7 +2982,7 @@ int32 Creature::ChargeBonus()
       
       bonus = max(0,min(10, bonus / 2)-1);
       
-      return ChargeBonusTable[bonus][min(29,GetStatiMag(CHARGING))];
+      return ChargeBonusTable[bonus][min<int>(29,GetStatiMag(CHARGING))];
 }
 
 bool Creature::canMoveThrough(EventInfo *e, int16 tx, int16 ty, 

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -167,7 +167,7 @@ long array_index(long index, long size) {
     ASSERT(index >= 0)
     ASSERT(size  >  0)
     ASSERT(size > index)
-    return max(0,min(index,size));
+    return std::max(0, std::min(index,size));
 }
 
 #endif
@@ -2324,7 +2324,7 @@ void TextTerm::TraceWindow(rID xID, int16 Event, VMachine *VM, hCode CP, bool ru
     
     /* Now, display the bytecode dump */
     int16 mid_screen = (sy-8)/2;
-    int16 first_line = (int16)max(0,trace_cursor - mid_screen);
+    int16 first_line = (int16)std::max(0,trace_cursor - mid_screen);
     int16 watch_size = (int16)(cLocals ? (cLocals+2) : 0);
     for(y=2;y!=(sy-(4+watch_size));y++)
       {

--- a/src/Djikstra.cpp
+++ b/src/Djikstra.cpp
@@ -139,7 +139,7 @@ bool Map::ShortestPath(uint8 sx, uint8 sy, uint8 tx, uint8 ty,
 
           if (Dist[x][y] + baseCost < Dist[nx][ny])
             {
-              Dist[nx][ny] = min(30000,Dist[x][y] + baseCost);
+              Dist[nx][ny] = std::min(30000,Dist[x][y] + baseCost);
               Parent[nx][ny] = x+y*256;
               PQInsert(nx+ny*256,Dist[nx][ny]);
             }
@@ -152,8 +152,8 @@ bool Map::ShortestPath(uint8 sx, uint8 sy, uint8 tx, uint8 ty,
 
     if (Dist[tx][ty] == 30000) {
       #ifdef DEBUG_DJIKSTRA
-      for (x = min(0,sx-30);x!=max(127,sx+30);x++)
-        for (y = min(0,sx-30);y!=max(127,sy+30);y++)
+      for (x = std::min(0,sx-30);x!=std::max(127,sx+30);x++)
+        for (y = std::min(0,sx-30);y!=std::max(127,sy+30);y++)
           if (Dist[x][y] != 30000)
             {
               At(x,y).Glyph =

--- a/src/Effects.cpp
+++ b/src/Effects.cpp
@@ -232,7 +232,7 @@ SkipSave:
           (e.DType == AD_FIRE && e.EActor->HasFeat(FT_LORE_OF_FLAMES)) ||
           (e.DType == AD_NECR && e.EActor->HasFeat(FT_LORE_OF_DEATH)) ||
           (e.DType == AD_ELEC && e.EActor->HasFeat(FT_LORE_OF_STORMS))) {
-        int16 bonus = max((e.vDmg * 20) / 100,1);
+        int16 bonus = std::max((e.vDmg * 20) / 100,1);
         e.strDmg += Format(" +%d Lore",bonus);
         e.vDmg += bonus; 
       } 
@@ -653,7 +653,7 @@ NotImmune:
     }
 
     if (e.EMagic->xval == AFRAID || e.EMagic->xval == CHARMED)
-        e.EActor->Exercise(A_CHA,max(0,random(4)+e.EVictim->ChallengeRating()-e.EActor->ChallengeRating()),ECHA_CHARM,45);
+        e.EActor->Exercise(A_CHA,std::max(0,random(4)+e.EVictim->ChallengeRating()-e.EActor->ChallengeRating()),ECHA_CHARM,45);
 
     if (e.eID && (TEFF(e.eID)->Schools & SC_ENC))
         if (e.EVictim->isCreature() && (e.EMagic->sval == WILL))
@@ -740,10 +740,10 @@ EvReturn Magic::Polymorph(EventInfo &e)
       {
         int16 best, bestCR, n;
         rID Candidates[40];
-        n = 3 + max<int>(0,e.EActor->Mod(A_INT));
+        n = 3 + std::max<int>(0,e.EActor->Mod(A_INT));
         for (i=0;i!=n;i++)
-          Candidates[i] = theGame->GetMonID(PUR_POLY,max(0,
-            e.EVictim->ChallengeRating()-4)/2,max(1,e.EVictim->ChallengeRating()/2),100,e.EMagic->yval);
+          Candidates[i] = theGame->GetMonID(PUR_POLY,std::max(0,
+            e.EVictim->ChallengeRating()-4)/2,std::max(1,e.EVictim->ChallengeRating()/2),100,e.EMagic->yval);
         if (e.EActor->isMonster()) {
           bestCR = 0;
           best = 0;
@@ -762,8 +762,8 @@ EvReturn Magic::Polymorph(EventInfo &e)
         mID = Candidates[best];
       }
     else
-      mID = theGame->GetMonID(PUR_POLY,max(0,e.EVictim->ChallengeRating()-4)/2,
-                                       max(1,e.EVictim->ChallengeRating()/2),
+      mID = theGame->GetMonID(PUR_POLY,std::max(0,e.EVictim->ChallengeRating()-4)/2,
+                                       std::max(1,e.EVictim->ChallengeRating()/2),
                                              100,e.EMagic->yval);
     if (!mID)
       return ABORT;
@@ -1033,9 +1033,9 @@ void Creature::Shapeshift(rID _mID, bool merge, Item* PolySource) {
 
     mID = _mID;
     SetImage();
-    cHP = (cHP * 100) / max(1, mHP + Attr[A_THP]);
+    cHP = (cHP * 100) / std::max(1, mHP + Attr[A_THP]);
     CalcHP();
-    cHP = max((cHP*(mHP + Attr[A_THP])) / 100, 1);
+    cHP = std::max((cHP*(mHP + Attr[A_THP])) / 100, 1);
     if (m && m->InBounds(x, y)) // ww: bugfix! 
         m->Update(x, y);
 }
@@ -1451,7 +1451,7 @@ EvReturn Magic::Summon(EventInfo &e) {
               cr->GainPermStati(ADJUST,e.EActor,SS_ENCH,A_STR,+4,e.eID,e.vCasterLev);
               cr->GainPermStati(ADJUST,e.EActor,SS_ENCH,A_CON,+4,e.eID,e.vCasterLev);
               cr->GainPermStati(ADJUST,e.EActor,SS_ENCH,A_THP,
-                    10 + max<int>(1,TEFF(e.eID)->Level)*5,e.eID,e.vCasterLev);
+                    10 + std::max<int>(1,TEFF(e.eID)->Level)*5,e.eID,e.vCasterLev);
             } 
         }
     if (e.EItem && e.EItem->isItem())
@@ -1986,7 +1986,7 @@ EvReturn Magic::Creation(EventInfo &e)
               return ABORT;
             if (e.EActor->onPlane() != PHASE_MATERIAL)
               ((Item *)t)->GainPermStati(PHASED,NULL,SS_MISC,e.EActor->onPlane());
-            ((Item*)t)->MakeMagical(0,min(5,e.vDmg/3));
+            ((Item*)t)->MakeMagical(0,std::min(5,e.vDmg/3));
             if (e.EMagic->xval & CREA_MANY)
               ((Item *)t)->SetQuantity(LevelAdjust(e.EMagic->yval,
                                                    e.vCasterLev));
@@ -2009,7 +2009,7 @@ EvReturn Magic::Creation(EventInfo &e)
                   t = Item::Create(iID);
                   if (!t)
                     return ABORT;
-                  ((Item*)t)->MakeMagical(xID,max(5,e.vDmg/3));
+                  ((Item*)t)->MakeMagical(xID,std::max(5,e.vDmg/3));
                   break;
                 }
               if (!t)
@@ -2115,7 +2115,7 @@ EvReturn Magic::Detect(EventInfo &e)
 EvReturn Magic::Travel(EventInfo &e)
   {
     int16 i, _x, _y;
-    e.vDmg = max<int>(e.vDmg,7);
+    e.vDmg = std::max<int>(e.vDmg,7);
 
     if (!e.EActor || e.EActor->isDead() || !e.EActor->m)
       return ABORT; 
@@ -2245,7 +2245,7 @@ EvReturn Magic::Healing(EventInfo &e)
     if ((e.EMagic->xval & HEAL_XP) && e.EVictim->XPDrained()) {
       e.EVictim->IPrint("Your vital force is renewed!");
       if (e.vDmg == 0) e.vDmg = 6; // ww:mysteriously, sometimes this happens
-      e.EVictim->RestoreXP(min((int)e.EVictim->XPDrained(),e.vDmg*500));
+      e.EVictim->RestoreXP(std::min((int)e.EVictim->XPDrained(),e.vDmg*500));
       /* ww: it's not uncommon to be down 6000 XP after a battle with 6
        * wraiths. 300 per potion doesn't cut it.  */ 
       id = true;
@@ -2258,7 +2258,7 @@ EvReturn Magic::Healing(EventInfo &e)
           amt = (int16)((e.EActor->cMana()*e.EMagic->yval)/10);
         else
           amt = 5000;
-        amt = min(e.vDmg,amt);
+        amt = std::min(e.vDmg,amt);
         if (!amt)
           goto SkipHeal;
         if (e.EMagic->yval)
@@ -2272,7 +2272,7 @@ EvReturn Magic::Healing(EventInfo &e)
           return DONE; 
           }         
        
-        amt = min<int>(max(0,(e.EVictim->mHP+e.EVictim->Attr[A_THP]) - e.EVictim->cHP),amt);
+        amt = std::min<int>(std::max(0,(e.EVictim->mHP+e.EVictim->Attr[A_THP]) - e.EVictim->cHP),amt);
         e.EVictim->cHP += amt;
         VPrint(e,"Your wounds heal<Str>!", "The <EVictim>'s wounds heal<Str>!",
           e.EVictim->cHP == (e.EVictim->mHP+e.EVictim->Attr[A_THP]) ? " fully" : "");
@@ -2298,7 +2298,7 @@ EvReturn Magic::Healing(EventInfo &e)
 
     if (e.EMagic->xval & HEAL_FATIGUE)
       if (e.EVictim->cFP < e.EVictim->GetAttr(A_FAT)) {
-        e.EVictim->cFP = min<int>(e.EVictim->GetAttr(A_FAT),
+        e.EVictim->cFP = std::min<int>(e.EVictim->GetAttr(A_FAT),
           e.EVictim->cFP + e.vDmg);
         e.EVictim->IPrint("You feel <Str>refreshed!",
           e.EVictim->cFP == e.EVictim->GetAttr(A_FAT) ? "fully " : "");

--- a/src/Effects.cpp
+++ b/src/Effects.cpp
@@ -740,7 +740,7 @@ EvReturn Magic::Polymorph(EventInfo &e)
       {
         int16 best, bestCR, n;
         rID Candidates[40];
-        n = 3 + max(0,e.EActor->Mod(A_INT));
+        n = 3 + max<int>(0,e.EActor->Mod(A_INT));
         for (i=0;i!=n;i++)
           Candidates[i] = theGame->GetMonID(PUR_POLY,max(0,
             e.EVictim->ChallengeRating()-4)/2,max(1,e.EVictim->ChallengeRating()/2),100,e.EMagic->yval);
@@ -1451,7 +1451,7 @@ EvReturn Magic::Summon(EventInfo &e) {
               cr->GainPermStati(ADJUST,e.EActor,SS_ENCH,A_STR,+4,e.eID,e.vCasterLev);
               cr->GainPermStati(ADJUST,e.EActor,SS_ENCH,A_CON,+4,e.eID,e.vCasterLev);
               cr->GainPermStati(ADJUST,e.EActor,SS_ENCH,A_THP,
-                    10 + max(1,TEFF(e.eID)->Level)*5,e.eID,e.vCasterLev);
+                    10 + max<int>(1,TEFF(e.eID)->Level)*5,e.eID,e.vCasterLev);
             } 
         }
     if (e.EItem && e.EItem->isItem())
@@ -2115,7 +2115,7 @@ EvReturn Magic::Detect(EventInfo &e)
 EvReturn Magic::Travel(EventInfo &e)
   {
     int16 i, _x, _y;
-    e.vDmg = max(e.vDmg,7);
+    e.vDmg = max<int>(e.vDmg,7);
 
     if (!e.EActor || e.EActor->isDead() || !e.EActor->m)
       return ABORT; 
@@ -2272,7 +2272,7 @@ EvReturn Magic::Healing(EventInfo &e)
           return DONE; 
           }         
        
-        amt = min(max(0,(e.EVictim->mHP+e.EVictim->Attr[A_THP]) - e.EVictim->cHP),amt);
+        amt = min<int>(max(0,(e.EVictim->mHP+e.EVictim->Attr[A_THP]) - e.EVictim->cHP),amt);
         e.EVictim->cHP += amt;
         VPrint(e,"Your wounds heal<Str>!", "The <EVictim>'s wounds heal<Str>!",
           e.EVictim->cHP == (e.EVictim->mHP+e.EVictim->Attr[A_THP]) ? " fully" : "");
@@ -2298,7 +2298,7 @@ EvReturn Magic::Healing(EventInfo &e)
 
     if (e.EMagic->xval & HEAL_FATIGUE)
       if (e.EVictim->cFP < e.EVictim->GetAttr(A_FAT)) {
-        e.EVictim->cFP = min(e.EVictim->GetAttr(A_FAT),
+        e.EVictim->cFP = min<int>(e.EVictim->GetAttr(A_FAT),
           e.EVictim->cFP + e.vDmg);
         e.EVictim->IPrint("You feel <Str>refreshed!",
           e.EVictim->cFP == e.EVictim->GetAttr(A_FAT) ? "fully " : "");

--- a/src/Encounter.cpp
+++ b/src/Encounter.cpp
@@ -765,7 +765,7 @@ EvReturn Map::enGenerate(EventInfo &e) {
       e.enXCR += (e.enDesAmt / 3) * (e.enXCR/2);   
       if (!(e.enFlags & EN_NOSLEEP))
         for (i=0;i!=(e.enDesAmt / 3);i++)
-          e.enSleep = max(e.enSleep,random(100)+1);
+          e.enSleep = max<int>(e.enSleep,random(100)+1);
       }
     e.enXCR = max(e.enXCR, XCR(e.enCR) * (int32)te->GetConst(MIN_XCR_MULT));
     e.enXCR = max(e.enXCR, (int32)te->GetConst(MIN_XCR));
@@ -913,7 +913,7 @@ EvReturn Map::enGenerate(EventInfo &e) {
       }
     Deviance = (int16)((abs(e.enXCR-totXCR) * 100L) / e.enXCR);
     if (e.enDesAmt)
-      Deviance += (int16)max(0,((abs(e.enDesAmt-cEncMem)*100L)/e.enDesAmt)-50);
+      Deviance += max<int16_t>(0,((abs(e.enDesAmt-cEncMem)*100L)/e.enDesAmt)-50);
     if (cEncMem > maxAmtByCR(e.enCR))
       Deviance += (cEncMem - maxAmtByCR(e.enCR))*100 / maxAmtByCR(e.enCR);
     if (Deviance > 50 && e.enTries < 5)
@@ -943,7 +943,7 @@ EvReturn Map::enGenerate(EventInfo &e) {
     /* Cap # of creatures at CR max */
     cEncMem = min(cEncMem,maxAmtByCR(e.enCR));
     /* HACKFIX */
-    cEncMem = min(cEncMem,5);
+    cEncMem = min<int>(cEncMem,5);
     
     if (e.enFlags & EN_DUMP)
       {
@@ -1326,7 +1326,7 @@ RetryPart:
             e.ep_pID = 0;
 
         if (te->HasFlag(NF_FREAKY) || ep->Flags & EP_FREAKY)
-            e.epFreaky = min(e.enFreaky, random(10) + 1);
+            e.epFreaky = min<int>(e.enFreaky, random(10) + 1);
         else
             e.epFreaky = 0;
 
@@ -1480,9 +1480,9 @@ EvReturn Map::enChooseMID(EventInfo &e) {
       
       
     if (e.enConstraint > 0x01000000)
-      maxCR = max(maxCR,min(e.enCR,TMON(e.enConstraint)->CR));
+      maxCR = max<int>(maxCR,min<int>(e.enCR,TMON(e.enConstraint)->CR));
       
-    maxCR = max(1,maxCR);
+    maxCR = max<int>(1,maxCR);
     
     /* If we have mandatory templates, keep lowering the maxCR
        on consecutive tries until we have room for all of them. */
@@ -1513,7 +1513,7 @@ EvReturn Map::enChooseMID(EventInfo &e) {
           for(i=0;i!=theGame->Modules[q]->szMon;i++)
             {
               TMonster *tm = &theGame->Modules[q]->QMon[i];
-              if (tm->CR > max(1,maxCR) && !e.isGetMinCR)
+              if (tm->CR > max<int>(1,maxCR) && !e.isGetMinCR)
                 continue;
               if (tm->HasFlag(M_NOGEN) && e.enConstraint < 0x01000000)
                 continue;
@@ -1786,7 +1786,7 @@ EvReturn Map::enGenMount(EventInfo &e)
     
     enCalcCurrPartXCR(e);
     maxCR = XCRtoCR(e.eimXCR - e.epCurrXCR);
-    maxCR = max(1,maxCR);
+    maxCR = max<int>(1,maxCR);
     lowCR = 36; lowIdx = -1;
     highCR = -6; highIdx = -1;
     
@@ -2544,7 +2544,7 @@ EvReturn Map::enBuildMon(EventInfo &e)
           goto PlaceAtSpot;
       
       rID Terrains[256];
-      for (int i=0;i!=min(256,OpenC);i++)
+      for (int i=0;i!=min<int>(256,OpenC);i++)
         Terrains[i] = TerrainAt(OpenX[i],OpenY[i]);
       
       Retry:
@@ -2639,7 +2639,7 @@ EvReturn Map::enBuildMon(EventInfo &e)
     mn->GainPermStati(ENCOUNTER,NULL,SS_MISC,e.cPart,e.enDesAmt,e.enID);
     
     Player *p;
-    if (mn->ChallengeRating() > max(2,e.enCR))
+    if (mn->ChallengeRating() > max<int>(2,e.enCR))
       if (p = theGame->GetPlayer(0)) {
         String str;
         str = XPrint("OOD monster <Obj> (CR <Num>) generated on "
@@ -2987,7 +2987,7 @@ static void MakeMagicWeaponArmour(Item *it, int _plusLevel,
   ASSERT(plusLevel >= 0); 
 
   if (plusLevel > 0) 
-    it->MakeMagical(0, max(1,min(5,plusLevel)));
+    it->MakeMagical(0, std::max(1,min(5,plusLevel)));
 
   return; 
 }
@@ -3035,11 +3035,11 @@ Item* Item::GenItem(uint16 Flags, rID xID, int16 Depth, int8 Luck, ItemGen *Gen)
        Wes, let me know if this is making characters way too powerful
        too early, or if it's even noticable, or what.
        */
-    maxlev = max(3, Depth);
+    maxlev = max<int>(3, Depth);
 
     if (random(5) && Luck <= 9) {
         maxlev += (Luck - 11) / 2;
-        maxlev = max(min(1, Depth), maxlev);
+        maxlev = max<int>(min<int>(1, Depth), maxlev);
     }
 
     /* For high-luck characters, 20% of items are adjusted by luck
@@ -3074,8 +3074,8 @@ Item* Item::GenItem(uint16 Flags, rID xID, int16 Depth, int8 Luck, ItemGen *Gen)
         minlev = 0;
     }
 
-    maxlev = max(maxlev, 1);
-    Depth = max(Depth, 1);
+    maxlev = max<int>(maxlev, 1);
+    Depth = max<int>(Depth, 1);
     minlev = max(maxlev - 4, 0);
     restart_count = 0;
     /* To prevent the "1000 restarts" message, minlev MUST be
@@ -3141,7 +3141,7 @@ Got_iID:
 
     if (theItem->isType(T_COIN)) {
         int32 val;
-        val = WealthByLevel[max(0, min(20, Depth))] / 4;
+        val = WealthByLevel[max(0, min<int>(20, Depth))] / 4;
         val *= 50 + random(100); // 50% to 150%
         val /= TITEM(iID)->Cost;
         theItem->Quantity = val;
@@ -3316,7 +3316,7 @@ SkipMagic:
             ((QItem *)theItem)->KnownQualities = 0xff;
     }
 
-    if (random(100) < max(maxlev, 5) && !theItem->isType(T_TOOL) &&
+    if (random(100) < max<int>(maxlev, 5) && !theItem->isType(T_TOOL) &&
         !theItem->isType(T_COIN)) {
         theItem->IFlags &= ~IF_CURSED;
         theItem->IFlags |= IF_BLESSED;

--- a/src/Encounter.cpp
+++ b/src/Encounter.cpp
@@ -542,16 +542,16 @@ EvReturn Map::enGenerate(EventInfo &e) {
       e.enDesAmt = 1;
     else if (e.enFlags & EN_ANYOPEN) {
       if (e.enDepth > 2)
-        e.enDesAmt = max(1,OpenC / 30);
+        e.enDesAmt = std::max(1,OpenC / 30);
       else if (e.enDepth == 2)
-        e.enDesAmt = max(1,OpenC / 50);
+        e.enDesAmt = std::max(1,OpenC / 50);
       else
-        e.enDesAmt = max(1,OpenC / 75);
+        e.enDesAmt = std::max(1,OpenC / 75);
       }
     else if (e.enFlags & EN_MULTIPLE)
       e.enDesAmt = 4 + random(5);
 
-    e.enDesAmt = min(e.enDesAmt, maxAmtByCR(e.enCR));
+    e.enDesAmt = std::min(e.enDesAmt, maxAmtByCR(e.enCR));
 
     if (e.enConstraint == MA_AQUATIC ||
         (e.enConstraint > 0x01000000 &&
@@ -765,10 +765,10 @@ EvReturn Map::enGenerate(EventInfo &e) {
       e.enXCR += (e.enDesAmt / 3) * (e.enXCR/2);   
       if (!(e.enFlags & EN_NOSLEEP))
         for (i=0;i!=(e.enDesAmt / 3);i++)
-          e.enSleep = max<int>(e.enSleep,random(100)+1);
+          e.enSleep = std::max<int>(e.enSleep,random(100)+1);
       }
-    e.enXCR = max(e.enXCR, XCR(e.enCR) * (int32)te->GetConst(MIN_XCR_MULT));
-    e.enXCR = max(e.enXCR, (int32)te->GetConst(MIN_XCR));
+    e.enXCR = std::max(e.enXCR, XCR(e.enCR) * (int32)te->GetConst(MIN_XCR_MULT));
+    e.enXCR = std::max(e.enXCR, (int32)te->GetConst(MIN_XCR));
     
     tWeight = 0;
     for(i=0;i!=nParts;i++)
@@ -913,7 +913,7 @@ EvReturn Map::enGenerate(EventInfo &e) {
       }
     Deviance = (int16)((abs(e.enXCR-totXCR) * 100L) / e.enXCR);
     if (e.enDesAmt)
-      Deviance += max<int16_t>(0,((abs(e.enDesAmt-cEncMem)*100L)/e.enDesAmt)-50);
+      Deviance += std::max<int16_t>(0,((abs(e.enDesAmt-cEncMem)*100L)/e.enDesAmt)-50);
     if (cEncMem > maxAmtByCR(e.enCR))
       Deviance += (cEncMem - maxAmtByCR(e.enCR))*100 / maxAmtByCR(e.enCR);
     if (Deviance > 50 && e.enTries < 5)
@@ -941,9 +941,9 @@ EvReturn Map::enGenerate(EventInfo &e) {
       e.enIsFormation = true;
     
     /* Cap # of creatures at CR max */
-    cEncMem = min(cEncMem,maxAmtByCR(e.enCR));
+    cEncMem = std::min(cEncMem,maxAmtByCR(e.enCR));
     /* HACKFIX */
-    cEncMem = min<int>(cEncMem,5);
+    cEncMem = std::min<int>(cEncMem,5);
     
     if (e.enFlags & EN_DUMP)
       {
@@ -1135,8 +1135,8 @@ bool okDesAmt(TEncounter *te, int16 des)
           { A = ep->Amt.Roll();
             B = ep->Amt.Roll();
             C = ep->Amt.Roll();
-            mn += min(A,min(B,C));
-            mx += max(A,max(B,C)); }
+            mn += std::min(A, std::min(B,C));
+            mx += std::max(A, std::max(B,C)); }
         else if (ep->Amt.Number && ep->Amt.Bonus)
           { mn += ep->Amt.Number;
             mx += ep->Amt.Bonus; }
@@ -1247,8 +1247,8 @@ EvReturn Map::enGenPart(EventInfo &e) {
         C = RNDAMT;
         D = RNDAMT;
         E = RNDAMT;
-        uBound = max(A, max(B, max(C, max(D, E))));
-        lBound = min(A, min(B, min(C, min(D, E))));
+        uBound = std::max({ A, B, C, D, E });
+        lBound = std::min({ A, B, C, D, E });
     }
 
     if (ep->Flags & EP_NOXCR) {
@@ -1257,16 +1257,16 @@ EvReturn Map::enGenPart(EventInfo &e) {
         else
             e.epAmt = 1;
     } else if (e.epMinAmt != 0 && e.epMinAmt == e.epMaxAmt) {
-        e.eimXCR = min(XCR(e.enCR), e.epXCR / e.epMinAmt);
+        e.eimXCR = std::min(XCR(e.enCR), e.epXCR / e.epMinAmt);
         e.epAmt = e.epMinAmt;
     } else {
         int16 minCR, maxCR;
         minCR = getMinCR(e);
         maxCR = getMaxCR(e);
-        maxCR = min(maxCR, e.enCR);
+        maxCR = std::min(maxCR, e.enCR);
         if (minCR == maxCR) {
             e.eimXCR = XCR(minCR);
-            e.epAmt = (int16)max(1, e.epXCR / e.eimXCR);
+            e.epAmt = (int16)std::max(1, e.epXCR / e.eimXCR);
             if (e.epMaxAmt)
                 if (e.epAmt > e.epMaxAmt)
                     e.epAmt = e.epMaxAmt;
@@ -1280,8 +1280,8 @@ EvReturn Map::enGenPart(EventInfo &e) {
                 e.eimXCR = (XCR(minCR) * 1 + XCR(maxCR) * 4) / 4;
             else
                 e.eimXCR = (XCR(minCR) * 2 + XCR(maxCR) * 2) / 4;
-            e.eimXCR = min(XCR(e.enCR), e.eimXCR);
-            e.epAmt = (int16)max(1, e.epXCR / e.eimXCR);
+            e.eimXCR = std::min(XCR(e.enCR), e.eimXCR);
+            e.epAmt = (int16)std::max(1, e.epXCR / e.eimXCR);
 
             if (e.epMaxAmt)
                 if (e.epAmt > e.epMaxAmt) {
@@ -1301,7 +1301,7 @@ EvReturn Map::enGenPart(EventInfo &e) {
                     if (e.eimXCR < XCR(minCR))
                         e.eimXCR = XCR(minCR);
                 }
-            e.eimXCR = min(XCR(e.enCR), e.eimXCR);
+            e.eimXCR = std::min(XCR(e.enCR), e.eimXCR);
         }
     }
 
@@ -1326,7 +1326,7 @@ RetryPart:
             e.ep_pID = 0;
 
         if (te->HasFlag(NF_FREAKY) || ep->Flags & EP_FREAKY)
-            e.epFreaky = min<int>(e.enFreaky, random(10) + 1);
+            e.epFreaky = std::min<int>(e.enFreaky, random(10) + 1);
         else
             e.epFreaky = 0;
 
@@ -1476,18 +1476,18 @@ EvReturn Map::enChooseMID(EventInfo &e) {
     
     /* Kludge: leave room for class template! */
     if (ep->Flags & EP_CLASSED)
-      maxCR = max(1,maxCR-2);
+      maxCR = std::max(1,maxCR-2);
       
       
     if (e.enConstraint > 0x01000000)
-      maxCR = max<int>(maxCR,min<int>(e.enCR,TMON(e.enConstraint)->CR));
+      maxCR = std::max<int>(maxCR,std::min<int>(e.enCR,TMON(e.enConstraint)->CR));
       
-    maxCR = max<int>(1,maxCR);
+    maxCR = std::max<int>(1,maxCR);
     
     /* If we have mandatory templates, keep lowering the maxCR
        on consecutive tries until we have room for all of them. */
     if (e.epTries > 5)
-      maxCR = max(0,maxCR - (e.epTries-5)/2);
+      maxCR = std::max(0,maxCR - (e.epTries-5)/2);
     
       
     if (ep->xID >= 0x01000000)
@@ -1513,7 +1513,7 @@ EvReturn Map::enChooseMID(EventInfo &e) {
           for(i=0;i!=theGame->Modules[q]->szMon;i++)
             {
               TMonster *tm = &theGame->Modules[q]->QMon[i];
-              if (tm->CR > max<int>(1,maxCR) && !e.isGetMinCR)
+              if (tm->CR > std::max<int>(1,maxCR) && !e.isGetMinCR)
                 continue;
               if (tm->HasFlag(M_NOGEN) && e.enConstraint < 0x01000000)
                 continue;
@@ -1786,7 +1786,7 @@ EvReturn Map::enGenMount(EventInfo &e)
     
     enCalcCurrPartXCR(e);
     maxCR = XCRtoCR(e.eimXCR - e.epCurrXCR);
-    maxCR = max<int>(1,maxCR);
+    maxCR = std::max<int>(1,maxCR);
     lowCR = 36; lowIdx = -1;
     highCR = -6; highIdx = -1;
     
@@ -1824,8 +1824,8 @@ EvReturn Map::enGenMount(EventInfo &e)
                   break;
                 theCR = TTEM(wtList[j])->CR.Adjust(theCR);
               }
-            lowCR = min(theCR,lowCR);
-            highCR = max(theCR,highCR);
+            lowCR = std::min(theCR,lowCR);
+            highCR = std::max(theCR,highCR);
             if (theCR == lowCR)
               lowIdx = i;
             if (theCR == highCR)
@@ -2420,7 +2420,7 @@ EvReturn Map::enBuildMon(EventInfo &e)
       mn->GainPermStati(SLEEPING,NULL,SS_MISC,SLEEP_NATURAL);
     /* LATER...
     if (mGroups[i].Flags & MGF_POISON) {
-      xID = theGame->GetEffectID(PUR_POISON,0,max(3,enCR));
+      xID = theGame->GetEffectID(PUR_POISON,0,std::max(3,enCR));
       for(it = mn->FirstInv();it;it = mn->NextInv())
         if (it->isType(T_WEAPON) || it->isType(T_MISSILE))
           if (it->HasIFlag(WT_PIERCING) || it->HasIFlag(WT_SLASHING)) 
@@ -2544,7 +2544,7 @@ EvReturn Map::enBuildMon(EventInfo &e)
           goto PlaceAtSpot;
       
       rID Terrains[256];
-      for (int i=0;i!=min<int>(256,OpenC);i++)
+      for (int i=0;i!=std::min<int>(256,OpenC);i++)
         Terrains[i] = TerrainAt(OpenX[i],OpenY[i]);
       
       Retry:
@@ -2639,7 +2639,7 @@ EvReturn Map::enBuildMon(EventInfo &e)
     mn->GainPermStati(ENCOUNTER,NULL,SS_MISC,e.cPart,e.enDesAmt,e.enID);
     
     Player *p;
-    if (mn->ChallengeRating() > max<int>(2,e.enCR))
+    if (mn->ChallengeRating() > std::max<int>(2,e.enCR))
       if (p = theGame->GetPlayer(0)) {
         String str;
         str = XPrint("OOD monster <Obj> (CR <Num>) generated on "
@@ -2912,7 +2912,7 @@ int16 MaxItemPlus(int16 MaxLev,rID eID)
     while (i != 6 && LevelAdjust(l,0,i) <= MaxLev)
       i++;
 
-    return max(1,i - 1);
+    return std::max(1,i - 1);
   }
 
 /* ww: currently we generate really horrible random-looking magical weapons
@@ -2987,7 +2987,7 @@ static void MakeMagicWeaponArmour(Item *it, int _plusLevel,
   ASSERT(plusLevel >= 0); 
 
   if (plusLevel > 0) 
-    it->MakeMagical(0, std::max(1,min(5,plusLevel)));
+    it->MakeMagical(0, std::max(1, std::min(5,plusLevel)));
 
   return; 
 }
@@ -3035,11 +3035,11 @@ Item* Item::GenItem(uint16 Flags, rID xID, int16 Depth, int8 Luck, ItemGen *Gen)
        Wes, let me know if this is making characters way too powerful
        too early, or if it's even noticable, or what.
        */
-    maxlev = max<int>(3, Depth);
+    maxlev = std::max<int>(3, Depth);
 
     if (random(5) && Luck <= 9) {
         maxlev += (Luck - 11) / 2;
-        maxlev = max<int>(min<int>(1, Depth), maxlev);
+        maxlev = std::max<int>(std::min<int>(1, Depth), maxlev);
     }
 
     /* For high-luck characters, 20% of items are adjusted by luck
@@ -3060,9 +3060,9 @@ Item* Item::GenItem(uint16 Flags, rID xID, int16 Depth, int8 Luck, ItemGen *Gen)
        IG_GOOD and IG_GREAT flags as well, decreasing exponentially with
        the number of artifacts already generated. */
     if (Flags & IG_GREAT)
-        minlev = max(0, maxlev - 2);
+        minlev = std::max(0, maxlev - 2);
     else if (Flags & IG_GOOD)
-        minlev = max(0, maxlev - 4);
+        minlev = std::max(0, maxlev - 4);
     else {
         if (xID && RES(xID)->Type == T_TDUNGEON)
             if (random(100) + 1 < (int16)TDUN(xID)->GetConst(CURSED_CHANCE)) {
@@ -3074,9 +3074,9 @@ Item* Item::GenItem(uint16 Flags, rID xID, int16 Depth, int8 Luck, ItemGen *Gen)
         minlev = 0;
     }
 
-    maxlev = max<int>(maxlev, 1);
-    Depth = max<int>(Depth, 1);
-    minlev = max(maxlev - 4, 0);
+    maxlev = std::max<int>(maxlev, 1);
+    Depth = std::max<int>(Depth, 1);
+    minlev = std::max(maxlev - 4, 0);
     restart_count = 0;
     /* To prevent the "1000 restarts" message, minlev MUST be
        zero, because most staple items are very low level! */
@@ -3141,7 +3141,7 @@ Got_iID:
 
     if (theItem->isType(T_COIN)) {
         int32 val;
-        val = WealthByLevel[max(0, min<int>(20, Depth))] / 4;
+        val = WealthByLevel[std::max(0, std::min<int>(20, Depth))] / 4;
         val *= 50 + random(100); // 50% to 150%
         val /= TITEM(iID)->Cost;
         theItem->Quantity = val;
@@ -3200,7 +3200,7 @@ Got_iID:
 NoSpecificWeaponFound:
         int isArmour = IType == T_ARMOUR || IType == T_SHIELD;
         int isShield = IType == T_SHIELD;
-        magicLevel = max(random(1 + maxlev - minlev) + minlev, random(1 + maxlev - minlev) + minlev);
+        magicLevel = std::max(random(1 + maxlev - minlev) + minlev, random(1 + maxlev - minlev) + minlev);
         //magicLevel += random(4) + random(4) - 3; // fake std dev ...
         //magicLevel *= 100;
         //magicLevel /= 150;
@@ -3316,7 +3316,7 @@ SkipMagic:
             ((QItem *)theItem)->KnownQualities = 0xff;
     }
 
-    if (random(100) < max<int>(maxlev, 5) && !theItem->isType(T_TOOL) &&
+    if (random(100) < std::max<int>(maxlev, 5) && !theItem->isType(T_TOOL) &&
         !theItem->isType(T_COIN)) {
         theItem->IFlags &= ~IF_CURSED;
         theItem->IFlags |= IF_BLESSED;

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -81,7 +81,7 @@ EvReturn Feature::Event(EventInfo &e) {
         if (e.EItem && e.EItem->isWeapon()) {
             ((Weapon *)e.EItem)->DoQualityDmgSingle(e);
         }
-        e.EActor->MakeNoise(max(10 - (e.EActor->SkillLevel(SK_MOVE_SIL) / 2), 1));
+        e.EActor->MakeNoise(std::max(10 - (e.EActor->SkillLevel(SK_MOVE_SIL) / 2), 1));
         if (isDead())
             e.Died = true;
         if (res != NOTHING)
@@ -947,7 +947,7 @@ void Player::MoveDepth(int16 NewDepth, bool safe) {
             if (c->isPlayer())
                 c->Timeout = 0;
             else if (c->isCreature())
-                c->Timeout = max<int>(c->Timeout, 1);
+                c->Timeout = std::max<int>(c->Timeout, 1);
     }
 }
   
@@ -984,8 +984,8 @@ Map* Game::GetDungeonMap(rID dID, int16 Depth, Player *pl, Map*TownLevel) {
         Fatal("Too deep in dungeon; MAX_DUNGEON_LEVELS is %d.", MAX_DUNGEON_LEVELS);
 
     DungeonID[i] = dID;
-    DungeonSize[i] = min<int>(MAX_DUNGEON_LEVELS, (int16)(RES(dID)->GetConst(DUN_DEPTH)));
-    DungeonLevels[i] = (hObj*)malloc(sizeof(hObj)*min<int>(MAX_DUNGEON_LEVELS, RES(dID)->GetConst(DUN_DEPTH) + 1));
+    DungeonSize[i] = std::min<int>(MAX_DUNGEON_LEVELS, (int16)(RES(dID)->GetConst(DUN_DEPTH)));
+    DungeonLevels[i] = (hObj*)malloc(sizeof(hObj) * std::min<int>(MAX_DUNGEON_LEVELS, RES(dID)->GetConst(DUN_DEPTH) + 1));
     memset(DungeonLevels[i], 0, sizeof(hObj)*(RES(dID)->GetConst(DUN_DEPTH) + 1));
 Found:
     n = i;

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -947,7 +947,7 @@ void Player::MoveDepth(int16 NewDepth, bool safe) {
             if (c->isPlayer())
                 c->Timeout = 0;
             else if (c->isCreature())
-                c->Timeout = max(c->Timeout, 1);
+                c->Timeout = max<int>(c->Timeout, 1);
     }
 }
   
@@ -984,8 +984,8 @@ Map* Game::GetDungeonMap(rID dID, int16 Depth, Player *pl, Map*TownLevel) {
         Fatal("Too deep in dungeon; MAX_DUNGEON_LEVELS is %d.", MAX_DUNGEON_LEVELS);
 
     DungeonID[i] = dID;
-    DungeonSize[i] = min(MAX_DUNGEON_LEVELS, (int16)(RES(dID)->GetConst(DUN_DEPTH)));
-    DungeonLevels[i] = (hObj*)malloc(sizeof(hObj)*min(MAX_DUNGEON_LEVELS, RES(dID)->GetConst(DUN_DEPTH) + 1));
+    DungeonSize[i] = min<int>(MAX_DUNGEON_LEVELS, (int16)(RES(dID)->GetConst(DUN_DEPTH)));
+    DungeonLevels[i] = (hObj*)malloc(sizeof(hObj)*min<int>(MAX_DUNGEON_LEVELS, RES(dID)->GetConst(DUN_DEPTH) + 1));
     memset(DungeonLevels[i], 0, sizeof(hObj)*(RES(dID)->GetConst(DUN_DEPTH) + 1));
 Found:
     n = i;

--- a/src/Fight.cpp
+++ b/src/Fight.cpp
@@ -544,12 +544,12 @@ SkipThisTarget:;
       // attack takes no time
     } else  if (isTWF) {
       Timeout += 
-          3000 / max((100 + min(Attr[A_SPD_MELEE],Attr[A_SPD_OFFHAND])*5),10) +
-          3000 / max((100 + max(Attr[A_SPD_MELEE],Attr[A_SPD_OFFHAND])*5),10) / 2;
+          3000 / std::max((100 + std::min(Attr[A_SPD_MELEE],Attr[A_SPD_OFFHAND])*5),10) +
+          3000 / std::max((100 + std::max(Attr[A_SPD_MELEE],Attr[A_SPD_OFFHAND])*5),10) / 2;
       }
     else
       Timeout += 3000 / 
-          max((100 + Attr[A_SPD_MELEE]*5),10);
+        std::max((100 + Attr[A_SPD_MELEE]*5),10);
     if (startedAfraid)
       Timeout *= 2;
     
@@ -691,7 +691,7 @@ EvReturn Creature::RAttack(EventInfo &e)
     return ABORT; 
     } 
 
-  e.vRange = max<int>(1,(e.EItem ? e.EItem : e.EItem2)->RangeInc(e.EActor));
+  e.vRange = std::max<int>(1,(e.EItem ? e.EItem : e.EItem2)->RangeInc(e.EActor));
 
   if (e.EActor->HasFeat(FT_FAR_SHOT))
     e.vRange *= 2;
@@ -974,10 +974,10 @@ SkipAttack:
     // attack takes no time
   } else if (e.EItem)
     Timeout += 3000 / 
-        max((100 + Attr[A_SPD_ARCHERY]*5),10);
+      std::max((100 + Attr[A_SPD_ARCHERY]*5),10);
   else
     Timeout += 3000 / 
-        max((100 + Attr[A_SPD_THROWN]*5),10);
+      std::max((100 + Attr[A_SPD_THROWN]*5),10);
   if (startedAfraid)
     Timeout *= 2;
 
@@ -1182,7 +1182,7 @@ EvReturn Creature::NAttack(EventInfo &e) /* this == EActor */
         && !e.EActor->HasStati(TRIED,FT_EXPERT_TACTICIAN,e.EVictim)) { 
         e.EActor->GainTempStati(TRIED,e.EVictim,1,SS_MISC,FT_EXPERT_TACTICIAN);
       // attack takes no time
-    } else Timeout += 2000 / max((100 + Attr[A_SPD_BRAWL]*5),10);
+    } else Timeout += 2000 / std::max((100 + Attr[A_SPD_BRAWL]*5),10);
     /* Touch Attacks are quicker */
     return res; 
   }
@@ -1955,7 +1955,7 @@ SkipSoundAttack:
         if (ReThrow(EV_STRIKE,e) == ABORT)
             return ABORT;
 
-        e.EActor->Timeout += 3000 / std::max((100 + min(e.EActor->Attr[A_SPD_BRAWL],e.EActor->Attr[A_MOV])*5), 10);
+        e.EActor->Timeout += 3000 / std::max((100 + std::min(e.EActor->Attr[A_SPD_BRAWL],e.EActor->Attr[A_MOV])*5), 10);
         if (startedAfraid)
             e.EActor->Timeout *= 2;
         return DONE;
@@ -2602,7 +2602,7 @@ EvReturn Creature::OAttack(EventInfo &e)
         e.vicHeld = true;
 
     e.isAoO = true; /* Attack of Opportunity flag */
-    e.EActor->AoO = max(0,e.EActor->AoO - 1);
+    e.EActor->AoO = std::max(0,e.EActor->AoO - 1);
 
     if (e.EVictim && e.EVictim->isCreature())
       if (!e.EVictim->HasStati(AFRAID) ||
@@ -2974,7 +2974,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
                !e.EActor->HasFeat(FT_POWER_DOUBLE_WEAPON))
         e.modStr /= 2;
       }
-    e.modStr = max<int>(0,e.modStr);
+    e.modStr = std::max<int>(0,e.modStr);
      
     e.subStr = false;
 
@@ -3130,14 +3130,14 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
       
       /* Victim is denied Dex bonus. */
       int loss = e.EVictim->AttrAdj[A_DEF][BONUS_ATTR]; 
-      e.vDef -= max(0,loss); 
+      e.vDef -= std::max(0,loss);
       if (loss > 0)
         e.strDef += Format(" -%d noDex",loss);
 
       loss = e.EVictim->AttrAdj[A_DEF][BONUS_DODGE];
       if (e.EVictim->StateFlags & MS_CASTING)
         loss = 0; 
-      e.vDef -= max(0,loss); 
+      e.vDef -= std::max(0,loss);
       if (loss > 0)
         e.strDef += Format(" -%d noDodge",loss);
 
@@ -3145,7 +3145,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
       loss = e.EVictim->AttrAdj[A_DEF][BONUS_WEAPON]; 
       if (e.EVictim->StateFlags & MS_CASTING)
         loss = 0; 
-      e.vDef -= max(0,loss); 
+      e.vDef -= std::max(0,loss);
       if (loss > 0)
         e.strDef += Format(" -%d noWep",loss);
       } 
@@ -3178,10 +3178,10 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
     
     if (TMON(e.EActor->tmID)->isMType(e.EActor->tmID, MA_HALFLING) && 
           e.AType == A_FIRE && e.EItem->iID == FIND("sling"))
-      e.vThreat -= max<int>(0,e.EActor->Mod(A_LUC));
+      e.vThreat -= std::max<int>(0,e.EActor->Mod(A_LUC));
     if (TMON(e.EActor->tmID)->isMType(e.EActor->tmID, MA_HALFLING) && 
           e.AType == A_HURL && e.EItem2->iID == FIND("rock"))
-      e.vThreat -= max<int>(0,e.EActor->Mod(A_LUC));
+      e.vThreat -= std::max<int>(0,e.EActor->Mod(A_LUC));
       
     
     if (e.EItem && e.EItem->HasStati(MASTERWORK))
@@ -3437,7 +3437,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
             int16 bon, cha;
             bon = e.EActor->SumStatiMag(SAVE_BONUS,SN_FEAR);
             cha = e.EVictim->Mod(A_CHA);
-            if (cha > max<int>(0,bon))
+            if (cha > std::max<int>(0,bon))
               { e.strDmg += Format(" %+d mein", -(cha - bon));
                 e.bDmg   -= (cha - bon); }
           }
@@ -3454,7 +3454,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
       e.vHit += 2;
       e.bDmg += 2;
       if (e.isGhostTouch || !e.vicIncor)
-        e.Dmg.Bonus += max<int>(0,e.EActor->Mod(A_STR));
+        e.Dmg.Bonus += std::max<int>(0,e.EActor->Mod(A_STR));
       e.strHit += " +2 GB";
       e.strDmg += " +2 GB";
       if (e.EActor->HasStati(SMITE_ABILITY)) {
@@ -3498,13 +3498,13 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
     if (e.EActor->HasAbility(CA_RETRIBUTIVE_STRIKE))
       if (e.EActor->HasStati(WOUNDED_BY,0,e.EVictim))
         if (e.EActor->GetStatiMag(WOUNDED_BY,0,e.EVictim) >= 
-              max(1,e.EActor->mHP / 10) )
+            std::max(1,e.EActor->mHP / 10) )
           {
             int16 i;
             //e.vThreat -= 2;
             i = ((e.EActor->GetStatiMag(WOUNDED_BY,0,e.EVictim) * 10) /
                   e.EActor->mHP);
-            i = max<int>(1,AbilityLevel(CA_RETRIBUTIVE_STRIKE));
+            i = std::max<int>(1,AbilityLevel(CA_RETRIBUTIVE_STRIKE));
             e.strHit += Format(" + %d Ret",i);
             e.strDmg += Format(" + %d Ret",i*2);
             e.vHit += i;
@@ -3563,10 +3563,10 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
     if (e.AType != A_FIRE && e.AType != A_HURL) {
       int bonus = 0; 
       if (e.EActor->HasStati(CHARGING))
-        bonus = max(bonus, e.EActor->ChargeBonus());
+        bonus = std::max(bonus, e.EActor->ChargeBonus());
       Creature * rider = (Creature *)e.EActor->GetStatiObj(MOUNT);
       if (rider && rider->HasStati(CHARGING))
-        bonus = max(bonus, rider->ChargeBonus());
+        bonus = std::max(bonus, rider->ChargeBonus());
       // in Hit(), we double the damage of a charging lance and handle
       // FT_SPIRITED_CHARGE
       if (bonus) { 
@@ -3578,7 +3578,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
         e.strDmg += Format (" %+d charge",bonus);
       }
 #if 0
-      int8 cb = ChargeBonus[min(29,GetStatiMag(CHARGING))], mult = 1;
+      int8 cb = ChargeBonus[std::min(29,GetStatiMag(CHARGING))], mult = 1;
       // ww: the textual description given to the user would lead one to
       // believe that these things stack ... and why not? 
       if (HasFeat(FT_POWER_CHARGE))
@@ -3608,7 +3608,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
       e.vDef += 4;
       }
     if (e.isAoO && e.isMoveAoO && e.EVictim->HasStati(CHARGING)) {
-      int32 bonus = max(e.EVictim->ChargeBonus(),1); 
+      int32 bonus = std::max(e.EVictim->ChargeBonus(),1);
       if (bonus) { 
         e.bDmg += (int16)bonus;
         e.strDmg += Format (" %+d charge",bonus);
@@ -4128,7 +4128,7 @@ EvReturn Creature::Strike(EventInfo &e) /* this == EActor */
               e.EVictim->IPrint("You fail to catch the thrown <Obj>!", e.EItem2);
           }                                  
                             
-    if ((e.vHit + e.vRoll >= max<int>(e.vDef,
+    if ((e.vHit + e.vRoll >= std::max<int>(e.vDef,
           (e.vRideCheck ? e.vRideCheck : -40))) || e.vRoll == 20)
       e.isHit = true;
     else
@@ -4157,7 +4157,7 @@ EvReturn Creature::Strike(EventInfo &e) /* this == EActor */
 
     if (!e.isHit && e.vRoll == 1 && (e.vHit + e.vtRoll) < e.vDef)
       e.isFumble = true;
-    if (e.isHit && (e.vRoll >= e.vThreat) && ((e.vHit + e.vtRoll) >= max(e.vRideCheck,e.vDef)))
+    if (e.isHit && (e.vRoll >= e.vThreat) && ((e.vHit + e.vtRoll) >= std::max(e.vRideCheck,e.vDef)))
       e.isCrit = true;
     else
       e.isCrit = false;  
@@ -4365,7 +4365,7 @@ EvReturn Creature::Strike(EventInfo &e) /* this == EActor */
          (e.EActor->HasStati(HIDING)) ) 
       ; // shoot from cover -- noise already covered
     else if (e.AType != A_COUP)
-      e.EActor->MakeNoise(max(10 - (e.EActor->SkillLevel(SK_MOVE_SIL) / 2),1));        
+      e.EActor->MakeNoise(std::max(10 - (e.EActor->SkillLevel(SK_MOVE_SIL) / 2),1));
     
     if (e.EActor->isCharacter())
       {
@@ -4389,7 +4389,7 @@ EvReturn Creature::Strike(EventInfo &e) /* this == EActor */
           L = 5000;
         
         if (ar && ar->HasQuality(IQ_FEATHERLIGHT))
-          L = min(10000,L*3);
+          L = std::min(10000,L*3);
           
         e.EPActor->fracFatigue += N;
         if (e.EPActor->fracFatigue >= L)
@@ -4425,7 +4425,7 @@ bool Creature::ManeuverCheck(EventInfo &e)
       v1 = (int8)e.EActor->GetBAB(S_MELEE);
     
     if (e.EVictim->InSlot(SL_WEAPON))
-      v2 = (int8)max(e.EVictim->GetBAB(S_MELEE),e.EVictim->GetBAB(S_BRAWL));
+      v2 = (int8)std::max(e.EVictim->GetBAB(S_MELEE),e.EVictim->GetBAB(S_BRAWL));
     else
       v2 = (int8)e.EVictim->GetBAB(S_BRAWL);
 
@@ -4706,7 +4706,7 @@ EvReturn Creature::Hit(EventInfo &e) /* this == EVictim!! */
       i /= 2;
       else
       i /= 3;
-      i = min(i,e.EActor->Mod2(A_STR));  
+      i = std::min(i,e.EActor->Mod2(A_STR));
       if (i) {
         e.bDmg += i;
         e.strDmg += Format(" %+d PA",i);
@@ -4722,7 +4722,7 @@ EvReturn Creature::Hit(EventInfo &e) /* this == EVictim!! */
       i /= 3;
       if (e.EActor->HasFeat(FT_ZEN_ARCHERY))
         limit += e.EActor->Mod2(A_WIS);
-      i = min(i,limit);
+      i = std::min(i,limit);
       if (i) {
         e.bDmg += i;
         e.strDmg += Format(" %+d AS",i);
@@ -4738,7 +4738,7 @@ EvReturn Creature::Hit(EventInfo &e) /* this == EVictim!! */
       vb = e.Dmg.Bonus;
       vn = vn * (5 + e.vCrit*5);
       vb = vb * (5 + e.vCrit*5);
-      e.Dmg.Number = (int8)max(2,vn/10);
+      e.Dmg.Number = (int8)std::max(2,vn/10);
       e.Dmg.Bonus  = (int8)(vb / 10);
       }
     else {
@@ -4751,7 +4751,7 @@ EvReturn Creature::Hit(EventInfo &e) /* this == EVictim!! */
   else
     e.vDmg = e.Dmg.Roll() + e.bDmg;
   
-  e.vDmg = max<int>(1,e.vDmg);
+  e.vDmg = std::max<int>(1,e.vDmg);
   ASSERT(e.vDmg > 0)
 
 
@@ -5058,7 +5058,7 @@ AfterEffects:
             single-classed barbarians are unrestricted. */
           if (e.EActor->isCharacter())
             if (e.EPActor->Level[1])
-              pen = min(pen,e.EActor->AbilityLevel(CA_BERSERK_RAGE));
+              pen = std::min(pen,e.EActor->AbilityLevel(CA_BERSERK_RAGE));
           
           e.EVictim->RemoveStati(ADJUST_CIRC,SS_ATTK,A_AID);
           e.EVictim->GainTempStati(ADJUST_CIRC,NULL,dur,SS_ATTK,A_AID,-pen,0,0);
@@ -5088,7 +5088,7 @@ AfterEffects:
               saDmg.Sides = TITEM(e.EItem2->iID)->HasFlag(WT_SUPER_SNEAK) ? 8 : 6;
         if (e.EItem)
           if (e.EItem->isType(T_WEAPON) || e.EItem->isType(T_BOW))
-            saDmg.Sides = max<int>(saDmg.Sides,TITEM(e.EItem->iID)->HasFlag(WT_SUPER_SNEAK) ? 8 : 6);
+            saDmg.Sides = std::max<int>(saDmg.Sides,TITEM(e.EItem->iID)->HasFlag(WT_SUPER_SNEAK) ? 8 : 6);
         i = saDmg.Roll(); 
         i -= e.EVictim->AbilityLevel(CA_NOBLE_AEGIS)*2;
         if (e.EVictim->AbilityLevel(CA_NOBLE_AEGIS))
@@ -5202,7 +5202,7 @@ AfterEffects:
             e.EActor->GainPermStati(PRONE,NULL,SS_ATTK);
             if (!e.EActor->SavingThrow(FORT,15 + e.EVictim->Mod(A_STR) + 
                                             e.EVictim->GetBAB(S_MELEE)))
-              e.EActor->GainTempStati(STUNNED,NULL,max<int>(1,e.EVictim->Mod(A_STR)),SS_ATTK);
+              e.EActor->GainTempStati(STUNNED,NULL, std::max<int>(1,e.EVictim->Mod(A_STR)),SS_ATTK);
           }
     
 
@@ -5211,7 +5211,7 @@ AfterEffects:
               !e.EItem->isKnown(KN_MAGIC|KN_CURSE|KN_PLUS)) 
         if (e.EActor->HasAbility(CA_LORE_OF_ARMS))
         {
-          int8 nSwings = NeededSwings [ min<int>(9,
+          int8 nSwings = NeededSwings[std::min<int>(9,
             e.EActor->AbilityLevel(CA_LORE_OF_ARMS)) ];
           e.EItem->swingCount++;
           if (e.EItem->swingCount > nSwings)
@@ -5231,7 +5231,7 @@ AfterEffects:
               !e.EItem2->isKnown(KN_MAGIC|KN_CURSE|KN_PLUS)) 
         if (e.EActor->HasAbility(CA_LORE_OF_ARMS))
         {
-          int8 nSwings = NeededSwings [ min<int>(9,
+          int8 nSwings = NeededSwings [std::min<int>(9,
             e.EActor->AbilityLevel(CA_LORE_OF_ARMS)) ];
           e.EItem2->swingCount++;
           if (e.remainingAmmo)
@@ -5259,7 +5259,7 @@ AfterEffects:
       if (ar && ar->swingCount < 30 && !ar->isKnown(KN_MAGIC|KN_CURSE|KN_PLUS)) 
         if (e.EVictim->AbilityLevel(CA_LORE_OF_ARMS) >= 3)
         {
-          int8 nSwings = NeededSwings [ min(9,
+          int8 nSwings = NeededSwings [std::min(9,
             e.EVictim->AbilityLevel(CA_LORE_OF_ARMS) - 2) ];
           
           ar->swingCount++;
@@ -5280,7 +5280,7 @@ AfterEffects:
       if (sh && sh->swingCount < 30 && sh->isType(T_SHIELD) && !sh->isKnown(KN_MAGIC|KN_CURSE|KN_PLUS)) 
         if (e.EVictim->AbilityLevel(CA_LORE_OF_ARMS) >= 3)
         {
-          int8 nSwings = NeededSwings [ min(9,
+          int8 nSwings = NeededSwings [std::min(9,
             e.EVictim->AbilityLevel(CA_LORE_OF_ARMS) - 2) ];
           
           sh->swingCount++;
@@ -5301,14 +5301,14 @@ AfterEffects:
       {
         if (e.EItem && (e.EItem->isGroup(WG_LIGHT|WG_DAGGERS|WG_FLEXIBLE) ||
               e.AType == A_FIRE || e.AType == A_HURL))
-          Exercise(A_DEX,random(6)+max(0,e.EVictim->ChallengeRating() - 
+          Exercise(A_DEX,random(6) + std::max(0,e.EVictim->ChallengeRating() -
                                         e.EActor->ChallengeRating()),EDEX_CRIT,75);
         if (e.EItem && e.EItem->Size() > GetAttr(A_SIZ))
-          Exercise(A_STR,random(8)+max(0,e.EVictim->ChallengeRating() - 
+          Exercise(A_STR,random(8) + std::max(0,e.EVictim->ChallengeRating() -
                                         e.EActor->ChallengeRating()),ESTR_CRIT,75);
         else if (e.EItem && e.EItem->Size() == GetAttr(A_SIZ) && !e.EItem->isGroup(WG_LIGHT)
                   && !(InSlot(SL_READY) && InSlot(SL_READY)->isType(T_WEAPON)))
-          Exercise(A_STR,random(4)+max(0,e.EVictim->ChallengeRating() - 
+          Exercise(A_STR,random(4) + std::max(0,e.EVictim->ChallengeRating() -
                                         e.EActor->ChallengeRating()),ESTR_CRIT,75);
       }
     if (e.AType == A_HURL && e.EItem2 && e.EItem2->Size() <= SZ_SMALL && !random(3))
@@ -5360,7 +5360,7 @@ EvReturn Creature::Miss(EventInfo &e)
 	                e.EVictim->HasFeat(FT_GREAT_THROW) &&
 	                !e.EActor->isDead())
 	              ThrowDmg(EV_DAMAGE,AD_KNOC,Dice::Roll(1,3,
-	                max<int>(0,e.EVictim->Mod(A_STR))), "Great Throw", e.EVictim, e.EActor);
+                      std::max<int>(0,e.EVictim->Mod(A_STR))), "Great Throw", e.EVictim, e.EActor);
   	        }
 
 		return DONE;
@@ -5421,7 +5421,7 @@ EvReturn Creature::Damage(EventInfo &e) {
         /* Allowance for clipping people with area spells for tactical reasons. */
         coll = false;
         if (e.EMagic && (e.EMagic->aval == AR_BALL || e.EMagic->aval == AR_BEAM || e.EMagic->aval == AR_BREATH || e.EMagic->aval == AR_GLOBE || e.EMagic->aval == AR_CHAIN)) {
-            mag = max(1, mag/2);
+            mag = std::max(1, mag/2);
             coll = true;
         }
 
@@ -5482,9 +5482,9 @@ IgnoreMorality:;
             {
                 int16 mod, percent;
                 Armour *ar = (Armour*) e.EVictim->InSlot(SL_ARMOUR);
-                mod = max<int>(0,e.EVictim->Mod(A_CON));
+                mod = std::max<int>(0,e.EVictim->Mod(A_CON));
                 percent = (e.EVictim->AbilityLevel(CA_TOUGH_AS_HELL) * 100) /
-                    (max<int>(1,e.EVictim->ChallengeRating()) + ((!ar) ? 0 :
+                    (std::max<int>(1,e.EVictim->ChallengeRating()) + ((!ar) ? 0 :
                     ar->isGroup(WG_HARMOUR) ? 9 :
                     (ar->isGroup(WG_MARMOUR) ? 6 : 3)));
                 mod = (mod * percent) / 100;
@@ -5492,7 +5492,7 @@ IgnoreMorality:;
                 {
                     e.strDmg += Format(" %+d TaH", -mod);
                     e.bDmg   -= mod;
-                    e.vDmg   = max(1, e.vDmg - mod);
+                    e.vDmg   = std::max(1, e.vDmg - mod);
                 }
             }
 
@@ -5741,7 +5741,7 @@ NotWImmune:
                                         /* ww: replaced for now by the weimer alternate penetration system 
                                         if (is_wepdmg(e.DType)) {
                                         if (e.EActor->Mod2(A_STR) > 0)
-                                        e.vPen = min(e.EActor->Mod2(A_STR),e.vArm/2);
+                                        e.vPen = std::min(e.EActor->Mod2(A_STR),e.vArm/2);
                                         else
                                         e.vPen = 0;
                                         if (e.EItem && e.EItem->isItem() && e.EItem->HasIFlag(WT_PENETRATING))
@@ -5784,7 +5784,7 @@ NotWImmune:
                                             // so that armour can absorb small and medium blows instead of
                                             // just small blows. I think that's still in the realm of
                                             // believability.
-                                            Percent = AbsorbTable[min<int>(e.vArm,16)][Col];
+                                            Percent = AbsorbTable[std::min<int>(e.vArm,16)][Col];
                                             int minAmount = 10 + e.vArm*2;
                                             if ((e.EItem && e.EItem->isItem() && 
                                                 e.EItem->HasIFlag(WT_PENETRATING)) ||
@@ -5815,7 +5815,7 @@ Absorbed:
                                                 return DONE;
                                             }
 
-                                            Percent = ArmourTable[min<int>(e.vArm,32)][Col];
+                                            Percent = ArmourTable[std::min<int>(e.vArm,32)][Col];
                                             if (e.EItem && e.EItem->isItem() && 
                                                 e.EItem->HasIFlag(WT_PENETRATING))
                                                 Percent /= 2;
@@ -5860,9 +5860,9 @@ Absorbed:
                                                     if (e.vDef > e.vHit + 19)
                                                         e.vDefRoll -= 1;
 
-                                                    e.vDefRoll = max<int>(1,e.vDefRoll);
+                                                    e.vDefRoll = std::max<int>(1,e.vDefRoll);
 
-                                                    e.aDmg = max(1, (e.aDmg*e.vDefRoll)/6);
+                                                    e.aDmg = std::max(1, (e.aDmg*e.vDefRoll)/6);
                                                     e.isDefRoll = true;
                                                     e.strXDmg = Format(" x (%d/6)",e.vDefRoll) + e.strXDmg;
                                                     /* People that benefit from Defensive Roll are going
@@ -5946,7 +5946,7 @@ WoundIgnored:
                                                                 SetStatiMag(WOUNDED_BY,0,e.EActor,
                                                                     GetStatiMag(WOUNDED_BY,0,e.EActor) + e.aDmg );
                                                                 SetStatiDur(WOUNDED_BY,0,e.EActor,
-                                                                    max(GetStatiDur(WOUNDED_BY,0,e.EActor) + e.aDmg*2, e.aDmg*2+10) );
+                                                                    std::max(GetStatiDur(WOUNDED_BY,0,e.EActor) + e.aDmg*2, e.aDmg*2+10) );
                                                             }
                                                             else
                                                                 GainTempStati(WOUNDED_BY,e.EActor,e.aDmg*2+10,SS_MISC,0,e.aDmg,0,0);
@@ -5978,7 +5978,7 @@ WoundIgnored:
 
                                                             if ((e.DType == AD_SLASH || e.DType == AD_PIERCE ||
                                                                 e.DType == AD_BLUNT) && HasStati(LEVITATION) && !isDead())
-                                                                ThrowDmg(EV_DAMAGE,AD_KNOC,e.vDmg / max(1,mHP/20),
+                                                                ThrowDmg(EV_DAMAGE,AD_KNOC,e.vDmg / std::max(1,mHP/20),
                                                                 "aerial damage knockback", e.EActor, e.EVictim, e.EItem, e.EItem2);
 
 
@@ -6250,7 +6250,7 @@ WoundIgnored:
                                         }
                                         if (e.AType == A_BITE && e.EActor && !e.EActor->isMType(MA_UNDEAD))
                                             subtype |= SA_POISON;
-                                        e.vDmg =  max<int>(1,e.Dmg.Roll());
+                                        e.vDmg = std::max<int>(1,e.Dmg.Roll());
                                         e.vDmg -= AbilityLevel(CA_STRONG_SOUL);
 
                                         if (e.vDmg <= 0) {
@@ -6261,12 +6261,12 @@ WoundIgnored:
 
                                         if (e.EVictim->SavingThrow(FORT,e.saveDC,subtype)) 
                                         {
-                                            e.vDmg = max(1,e.vDmg/2);
+                                            e.vDmg = std::max(1,e.vDmg/2);
                                             e.Resist = true;
                                         }
 
                                         if (e.EVictim->HasStati(SUSTAIN,at))
-                                            e.vDmg = max(0,e.vDmg - e.EVictim->SumStatiMag(SUSTAIN,at));
+                                            e.vDmg = std::max(0,e.vDmg - e.EVictim->SumStatiMag(SUSTAIN,at));
                                         if (!e.vDmg || Attr[at] <= 0) {
                                             e.Immune = true;
                                             break;
@@ -6330,14 +6330,14 @@ WoundIgnored:
                                         else {
                                             if (e.EVictim->HasStati(ADJUST_DMG,A_AID))
                                                 e.EVictim->GetStati(ADJUST_DMG,A_AID)->Mag -= 
-                                                e.vDmg / max(1,e.EVictim->ChallengeRating() * 5);
+                                                e.vDmg / std::max(1,e.EVictim->ChallengeRating() * 5);
                                             else
                                                 // ww: the signs were reversed here, so one hit from a
                                                 // spectre actually gave another creature a +1 neglev bonus
                                                 // ... :-) 
                                                 e.EVictim->GainPermStati(ADJUST_DMG,NULL,SS_ATTK,A_AID,
-                                                -(max(1,e.vDmg / max(1,e.EVictim->ChallengeRating() * 5))));
-                                            lv = max<int>(1,e.EVictim->ChallengeRating());
+                                                -(std::max(1,e.vDmg / std::max(1,e.EVictim->ChallengeRating() * 5))));
+                                            lv = std::max<int>(1,e.EVictim->ChallengeRating());
                                             lv += e.EVictim->SumStatiMag(ADJUST_DMG,A_AID);
                                             if (lv <= 0)
                                                 ReThrow(EV_DEATH,e);
@@ -6809,7 +6809,7 @@ EvReturn Creature::PDamage(EventInfo &e)
            comes from hallucinatory terrain -- but it's still good because
            GetStatiVal will return -1, which includes IL_SPECTRAL, and all
            terrain illusions are assumed to be spectral by default. */
-        e.EVictim->SetStatiDur(ILLUS_DMG,-1,e.EActor, max<int>(
+        e.EVictim->SetStatiDur(ILLUS_DMG,-1,e.EActor, std::max<int>(
            e.EVictim->GetStatiMag(ILLUS_DMG,-1,e.EActor), Dice::Roll(3,6) *
            ( e.EActor->GetStatiVal(ILLUSION) & IL_SPECTRAL ? 100 : 1 ) ) );    
         e.EVictim->cHP -= e.aDmg;
@@ -7080,7 +7080,7 @@ EvReturn Creature::Death(EventInfo &e)
                     curDur = cr->GetEffStatiDur(ADJUST_MOR,eID,-1,e.EActor);
                     curMod = cr->GetEffStatiMag(ADJUST_MOR,eID,-1,e.EActor);
                     cr->SetEffStatiDur(ADJUST_MOR,eID,curDur + dur,-1,e.EActor);
-                    cr->SetEffStatiMag(ADJUST_MOR,eID,max(curMod,mod),-1,e.EActor);
+                    cr->SetEffStatiMag(ADJUST_MOR,eID,std::max(curMod,mod),-1,e.EActor);
                   }
                 else
                   cr->GainTempStati(ADJUST_MOR,e.EActor,dur,SS_MISC,A_AID,mod,eID);
@@ -7175,8 +7175,8 @@ EvReturn Player::Death(EventInfo &e)
             XPCost = TotalXP();
             XPCost *= 15;
             XPCost /= 100;
-            XPCost = max(750,XPCost);
-            IPrint("You lose <Num> xp.", min(TotalXP(),XPCost));
+            XPCost = std::max(750,XPCost);
+            IPrint("You lose <Num> xp.", std::min(TotalXP(),XPCost));
             LoseXP(XPCost);
           }
         if (AttrDeath) {
@@ -7227,7 +7227,7 @@ void Weapon::QualityDmgSingle(EventInfo &e, int32 q)
         if (e.EActor->cHP < e.EActor->mHP+e.EActor->Attr[A_THP]) 
           /* ww: this logic was backwards before! */
         {
-          e.EActor->cHP = min(e.EActor->cHP + e.vDmg / 4,
+          e.EActor->cHP = std::min(e.EActor->cHP + e.vDmg / 4,
               e.EActor->mHP+e.EActor->Attr[A_THP]);
           DPrint(e,"Your wounds heal<str>!",
               "The <EActor>'s wounds heal<Str>!",
@@ -7683,7 +7683,7 @@ int16 Creature::WeaponSaveDC(Item *wp, int16 at)
       break;
       case WT_STUNNING: 
       case WT_KNOCKDOWN:
-        DC += Mod2(A_STR) + min<int16_t>(wp->Weight() / (40 * wp->Quantity), 5) + ((ti->Size - SZ_MEDIUM) * 2);
+        DC += Mod2(A_STR) + std::min<int16_t>(wp->Weight() / (40 * wp->Quantity), 5) + ((ti->Size - SZ_MEDIUM) * 2);
         break; 
       default:  
         Error("Unknown type of Weapon Save DC");

--- a/src/Fight.cpp
+++ b/src/Fight.cpp
@@ -691,7 +691,7 @@ EvReturn Creature::RAttack(EventInfo &e)
     return ABORT; 
     } 
 
-  e.vRange = max(1,(e.EItem ? e.EItem : e.EItem2)->RangeInc(e.EActor));
+  e.vRange = max<int>(1,(e.EItem ? e.EItem : e.EItem2)->RangeInc(e.EActor));
 
   if (e.EActor->HasFeat(FT_FAR_SHOT))
     e.vRange *= 2;
@@ -1193,7 +1193,7 @@ EvReturn Creature::NAttack(EventInfo &e) /* this == EActor */
     { buf[0].AType = A_PUNC;
       buf[0].DType = AD_BLUNT;
       buf[0].u.a.Dmg =
-        MonkDamage[max(1,e.EActor->
+        MonkDamage[std::max<int>(1,e.EActor->
           AbilityLevel(CA_UNARMED_STRIKE))];
       max = 1; }
   else 
@@ -1374,7 +1374,7 @@ DoneSequence:
       && !e.EActor->HasStati(TRIED,FT_EXPERT_TACTICIAN,e.EVictim)) { 
     e.EActor->GainTempStati(TRIED,e.EVictim,1,SS_MISC,FT_EXPERT_TACTICIAN);
     // takes no time
-  } else Timeout += 3000 / max((100 + Attr[A_SPD_BRAWL]*5),10);
+  } else Timeout += 3000 / std::max((100 + Attr[A_SPD_BRAWL]*5),10);
 
   if (startedAfraid)
     Timeout *= 2;
@@ -1516,7 +1516,7 @@ OvercomeNausea:
 
         te->ef.pval = ta->u.a.Dmg;
         te->ef.pval.Number += e.EActor->GetPower(0)*2;
-        te->ef.pval.Number = max(1,e.Dmg.Number);
+        te->ef.pval.Number = std::max<int>(1,e.Dmg.Number);
         e.Dmg = te->ef.pval;
         te->ef.lval = 3 + e.EActor->ChallengeRating()/2;
         e.vRange = te->ef.lval;
@@ -1600,7 +1600,7 @@ OvercomeNausea:
                             e.EMap->SetQueue(QUEUE_DAMAGE_MSG);
                             do {
                                 e.Dmg    = ta->u.a.Dmg;
-                                e.vDmg   = max(1,e.Dmg.Roll());
+                                e.vDmg   = std::max<int>(1,e.Dmg.Roll());
                                 e.DType  = ta->DType;
                                 e.saveDC = (int8)e.EActor->GetPower(ta->u.a.DC);
                                 e.isHit = true; 
@@ -1638,7 +1638,7 @@ SkipSoundAttack:
                     e.EActor->Reveal(true);
                     EventInfo e2 = e; 
                     e2.Dmg    = ta->u.a.Dmg;
-                    e2.vDmg   = max(1,e2.Dmg.Roll());
+                    e2.vDmg   = std::max<int>(1,e2.Dmg.Roll());
                     e2.strDmg = Format(" (%d) (proximity)",e2.vDmg);
                     e2.DType  = ta->DType;
                     e2.saveDC = (int8)e2.EActor->GetPower(ta->u.a.DC);
@@ -1683,7 +1683,7 @@ SkipSoundAttack:
                 TAttack * ta = &buf[i]; 
                 if (ta->AType == A_GAZE) {
                     e.Dmg    = ta->u.a.Dmg;
-                    e.vDmg   = max(1,e.Dmg.Roll());
+                    e.vDmg   = std::max<int>(1,e.Dmg.Roll());
                     e.DType  = ta->DType;
                     e.saveDC = (int8)e.EActor->GetPower(ta->u.a.DC);
                     e.strDmg = ""; 
@@ -1821,7 +1821,7 @@ SkipSoundAttack:
             IPrint("You're still off balance from the last great blow.");
             return ABORT;
         }
-        fc = max(0,2 - e.EActor->AbilityLevel(CA_MIGHTY_STROKE));
+        fc = std::max(0,2 - e.EActor->AbilityLevel(CA_MIGHTY_STROKE));
         if (fc && !e.EActor->LoseFatigue(fc,true))
             return ABORT;
 
@@ -1854,10 +1854,10 @@ SkipSoundAttack:
             return ABORT;
 
         if (e.EActor->HasFeat(FT_MASTER_GREAT_BLOW)) {
-            e.EActor->Timeout += 3000 / max((100 + e.EActor->Attr[e.EItem ? A_SPD_MELEE : A_SPD_BRAWL]*5),10);
+            e.EActor->Timeout += 3000 / std::max((100 + e.EActor->Attr[e.EItem ? A_SPD_MELEE : A_SPD_BRAWL]*5),10);
             e.EActor->GainTempStati(EXPOSED,NULL,1,SS_MISC,0,2);
         } else {
-            e.EActor->Timeout += 5000 / max((100 + e.EActor->Attr[e.EItem ? A_SPD_MELEE : A_SPD_BRAWL]*5),10);
+            e.EActor->Timeout += 5000 / std::max((100 + e.EActor->Attr[e.EItem ? A_SPD_MELEE : A_SPD_BRAWL]*5),10);
             e.EActor->GainTempStati(EXPOSED,NULL,2,SS_MISC,0,2);
         }
         if (startedAfraid)
@@ -1910,7 +1910,7 @@ SkipSoundAttack:
         e.isPrecision = true;
         if (ReThrow(EV_STRIKE, e) == ABORT)
             return ABORT;
-        e.EActor->Timeout += 3000 / max((100 + e.EActor->Attr[e.EItem ? A_SPD_MELEE : A_SPD_BRAWL]*5),10);
+        e.EActor->Timeout += 3000 / std::max((100 + e.EActor->Attr[e.EItem ? A_SPD_MELEE : A_SPD_BRAWL]*5),10);
         e.EActor->Timeout += 45;
         if (startedAfraid)
             e.EActor->Timeout *= 2;
@@ -1955,7 +1955,7 @@ SkipSoundAttack:
         if (ReThrow(EV_STRIKE,e) == ABORT)
             return ABORT;
 
-        e.EActor->Timeout += 3000 / max((100 + min(e.EActor->Attr[A_SPD_BRAWL],e.EActor->Attr[A_MOV])*5), 10);
+        e.EActor->Timeout += 3000 / std::max((100 + min(e.EActor->Attr[A_SPD_BRAWL],e.EActor->Attr[A_MOV])*5), 10);
         if (startedAfraid)
             e.EActor->Timeout *= 2;
         return DONE;
@@ -2006,9 +2006,9 @@ SkipSoundAttack:
         if (e.isCounterTrip)
             return DONE;
         if (e.EActor->AttackMode() == S_MELEE) 
-            e.EActor->Timeout = 3000 / max((100 + e.EActor->Attr[A_SPD_MELEE]*5),10);
+            e.EActor->Timeout = 3000 / std::max((100 + e.EActor->Attr[A_SPD_MELEE]*5),10);
         else
-            e.EActor->Timeout = 3000 / max((100 + e.EActor->Attr[A_SPD_BRAWL]*5),10);
+            e.EActor->Timeout = 3000 / std::max((100 + e.EActor->Attr[A_SPD_BRAWL]*5),10);
         if (startedAfraid)
             e.EActor->Timeout *= 2;
 
@@ -2058,9 +2058,9 @@ SkipSoundAttack:
             return DONE;
 
         if (e.EActor->AttackMode() == S_MELEE) 
-            e.EActor->Timeout += 3000 / max((100 + e.EActor->Attr[A_SPD_MELEE]*5),10);
+            e.EActor->Timeout += 3000 / std::max((100 + e.EActor->Attr[A_SPD_MELEE]*5),10);
         else
-            e.EActor->Timeout += 3000 / max((100 + e.EActor->Attr[A_SPD_BRAWL]*5),10);
+            e.EActor->Timeout += 3000 / std::max((100 + e.EActor->Attr[A_SPD_BRAWL]*5),10);
         if (startedAfraid)
             e.EActor->Timeout *= 2;
         return DONE;      
@@ -2098,7 +2098,7 @@ SkipSoundAttack:
             return ABORT;
 
         if (!e.isHit)
-            e.EActor->Timeout += 3000 / max((100 + e.EActor->Attr[A_SPD_BRAWL]*5),10);
+            e.EActor->Timeout += 3000 / std::max((100 + e.EActor->Attr[A_SPD_BRAWL]*5),10);
         else
             e.EActor->Timeout += 30;
         if (startedAfraid)
@@ -2182,7 +2182,7 @@ SkipRepeat:;
         e.saveDC = -1;
         e.Dmg = DmgVal(S_BRAWL, (!e.ETarget->isCreature()) || 
             (e.EVictim->GetAttr(A_SIZ) > SZ_MEDIUM));
-        e.Dmg.Bonus += max(0,(Mod(A_STR)+1)/2);
+        e.Dmg.Bonus += std::max(0,(Mod(A_STR)+1)/2);
         if (ReThrow(EV_STRIKE,e) == ABORT)
             return ABORT;
         // wow, I don't know what this massive timeout is about, but here's
@@ -2191,10 +2191,10 @@ SkipRepeat:;
         // submission while you can't react! 
         if (e.ETarget->isCreature())
             Timeout += 5000 / 
-            max((100 + Attr[A_SPD_BRAWL]*5),10);
+            std::max((100 + Attr[A_SPD_BRAWL]*5),10);
         else
             Timeout += 1000 / 
-            max((100 + Attr[A_SPD_BRAWL]*5),10);
+            std::max((100 + Attr[A_SPD_BRAWL]*5),10);
         if (startedAfraid)
             e.EActor->Timeout *= 2;
         break;
@@ -2209,7 +2209,7 @@ SkipRepeat:;
             }
         }  
         if (e.EVictim->HasStati(SLEEPING) || 
-            (e.EVictim->HasStati(PARALYSIS,PARA_HELD) && !(max(e.EVictim->SkillLevel(SK_CONCENT),e.EVictim->SkillLevel(SK_ESCAPE_ART)) >= 15)) ||
+            (e.EVictim->HasStati(PARALYSIS,PARA_HELD) && !(std::max(e.EVictim->SkillLevel(SK_CONCENT),e.EVictim->SkillLevel(SK_ESCAPE_ART)) >= 15)) ||
             (e.EVictim->HasStati(STUCK) && e.EVictim->HasStati(PRONE) && e.EActor->SkillLevel(SK_FIND_WEAKNESS) >= 20))
             ; // OK, victim cannot defend
         else {
@@ -2302,12 +2302,12 @@ SkipRepeat:;
         e.vHit = (int8)e.EActor->Attr[A_HIT_BRAWL];
         e.vDef = e.ETarget->isCreature() ? e.EVictim->getDef() : 0;
         e.DType = AD_KNOC; e.saveDC = -1;
-        e.Dmg.Set(1,max(1,e.EActor->Mod(A_STR) + 1),0);
+        e.Dmg.Set(1, std::max(1,e.EActor->Mod(A_STR) + 1),0);
 
         if (ReThrow(EV_STRIKE,e) == ABORT)
             return ABORT;
 
-        e.EActor->Timeout += 3000 / max((100 + e.EActor->Attr[A_SPD_BRAWL]*5),10);
+        e.EActor->Timeout += 3000 / std::max((100 + e.EActor->Attr[A_SPD_BRAWL]*5),10);
         if (startedAfraid)
             e.EActor->Timeout *= 2;
         return DONE;
@@ -2367,7 +2367,7 @@ SkipRepeat:;
             IPrint("But there's nobody nearby!");
             return ABORT;
         }
-        e.EActor->Timeout += 5000 / max((100 + e.EActor->Attr[EInSlot(SL_WEAPON) ? A_SPD_MELEE : A_SPD_BRAWL]*5),10);
+        e.EActor->Timeout += 5000 / std::max((100 + e.EActor->Attr[EInSlot(SL_WEAPON) ? A_SPD_MELEE : A_SPD_BRAWL]*5),10);
         if (startedAfraid)
             e.EActor->Timeout *= 2;
         break;  
@@ -2456,7 +2456,7 @@ SkipRepeat:;
         e.vCrit   = (int8)e.EItem->CritMult(e.EActor);
         if (ReThrow(EV_STRIKE,e) == ABORT)
             return ABORT;
-        Timeout += 3000 / max((100 + Attr[A_SPD_MELEE]*5),10);
+        Timeout += 3000 / std::max((100 + Attr[A_SPD_MELEE]*5),10);
         if (startedAfraid)
             e.EActor->Timeout *= 2;
         break;
@@ -2491,7 +2491,7 @@ SkipRepeat:;
         }
         if (!LoseFatigue(1,true))
             return ABORT;
-        GainTempStati(SPRINTING,NULL,1 + max(0,Mod(A_CON)),SS_MISC);
+        GainTempStati(SPRINTING,NULL,1 + std::max<int>(0,Mod(A_CON)),SS_MISC);
         IDPrint("You push yourself to the limit!",
             "The <Obj> puts on a burst of speed!",this);
         return DONE;    
@@ -2974,7 +2974,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
                !e.EActor->HasFeat(FT_POWER_DOUBLE_WEAPON))
         e.modStr /= 2;
       }
-    e.modStr = max(0,e.modStr);
+    e.modStr = max<int>(0,e.modStr);
      
     e.subStr = false;
 
@@ -3178,10 +3178,10 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
     
     if (TMON(e.EActor->tmID)->isMType(e.EActor->tmID, MA_HALFLING) && 
           e.AType == A_FIRE && e.EItem->iID == FIND("sling"))
-      e.vThreat -= max(0,e.EActor->Mod(A_LUC));
+      e.vThreat -= max<int>(0,e.EActor->Mod(A_LUC));
     if (TMON(e.EActor->tmID)->isMType(e.EActor->tmID, MA_HALFLING) && 
           e.AType == A_HURL && e.EItem2->iID == FIND("rock"))
-      e.vThreat -= max(0,e.EActor->Mod(A_LUC));  
+      e.vThreat -= max<int>(0,e.EActor->Mod(A_LUC));
       
     
     if (e.EItem && e.EItem->HasStati(MASTERWORK))
@@ -3437,7 +3437,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
             int16 bon, cha;
             bon = e.EActor->SumStatiMag(SAVE_BONUS,SN_FEAR);
             cha = e.EVictim->Mod(A_CHA);
-            if (cha > max(0,bon))
+            if (cha > max<int>(0,bon))
               { e.strDmg += Format(" %+d mein", -(cha - bon));
                 e.bDmg   -= (cha - bon); }
           }
@@ -3454,7 +3454,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
       e.vHit += 2;
       e.bDmg += 2;
       if (e.isGhostTouch || !e.vicIncor)
-        e.Dmg.Bonus += max(0,e.EActor->Mod(A_STR));
+        e.Dmg.Bonus += max<int>(0,e.EActor->Mod(A_STR));
       e.strHit += " +2 GB";
       e.strDmg += " +2 GB";
       if (e.EActor->HasStati(SMITE_ABILITY)) {
@@ -3504,7 +3504,7 @@ EvReturn Creature::PreStrike(EventInfo &e) /* this == EActor */
             //e.vThreat -= 2;
             i = ((e.EActor->GetStatiMag(WOUNDED_BY,0,e.EVictim) * 10) /
                   e.EActor->mHP);
-            i = max(1,AbilityLevel(CA_RETRIBUTIVE_STRIKE));
+            i = max<int>(1,AbilityLevel(CA_RETRIBUTIVE_STRIKE));
             e.strHit += Format(" + %d Ret",i);
             e.strDmg += Format(" + %d Ret",i*2);
             e.vHit += i;
@@ -4128,7 +4128,7 @@ EvReturn Creature::Strike(EventInfo &e) /* this == EActor */
               e.EVictim->IPrint("You fail to catch the thrown <Obj>!", e.EItem2);
           }                                  
                             
-    if ((e.vHit + e.vRoll >= max(e.vDef,
+    if ((e.vHit + e.vRoll >= max<int>(e.vDef,
           (e.vRideCheck ? e.vRideCheck : -40))) || e.vRoll == 20)
       e.isHit = true;
     else
@@ -4751,7 +4751,7 @@ EvReturn Creature::Hit(EventInfo &e) /* this == EVictim!! */
   else
     e.vDmg = e.Dmg.Roll() + e.bDmg;
   
-  e.vDmg = max(1,e.vDmg);
+  e.vDmg = max<int>(1,e.vDmg);
   ASSERT(e.vDmg > 0)
 
 
@@ -5088,7 +5088,7 @@ AfterEffects:
               saDmg.Sides = TITEM(e.EItem2->iID)->HasFlag(WT_SUPER_SNEAK) ? 8 : 6;
         if (e.EItem)
           if (e.EItem->isType(T_WEAPON) || e.EItem->isType(T_BOW))
-            saDmg.Sides = max(saDmg.Sides,TITEM(e.EItem->iID)->HasFlag(WT_SUPER_SNEAK) ? 8 : 6);
+            saDmg.Sides = max<int>(saDmg.Sides,TITEM(e.EItem->iID)->HasFlag(WT_SUPER_SNEAK) ? 8 : 6);
         i = saDmg.Roll(); 
         i -= e.EVictim->AbilityLevel(CA_NOBLE_AEGIS)*2;
         if (e.EVictim->AbilityLevel(CA_NOBLE_AEGIS))
@@ -5202,7 +5202,7 @@ AfterEffects:
             e.EActor->GainPermStati(PRONE,NULL,SS_ATTK);
             if (!e.EActor->SavingThrow(FORT,15 + e.EVictim->Mod(A_STR) + 
                                             e.EVictim->GetBAB(S_MELEE)))
-              e.EActor->GainTempStati(STUNNED,NULL,max(1,e.EVictim->Mod(A_STR)),SS_ATTK);          
+              e.EActor->GainTempStati(STUNNED,NULL,max<int>(1,e.EVictim->Mod(A_STR)),SS_ATTK);
           }
     
 
@@ -5211,7 +5211,7 @@ AfterEffects:
               !e.EItem->isKnown(KN_MAGIC|KN_CURSE|KN_PLUS)) 
         if (e.EActor->HasAbility(CA_LORE_OF_ARMS))
         {
-          int8 nSwings = NeededSwings [ min(9,
+          int8 nSwings = NeededSwings [ min<int>(9,
             e.EActor->AbilityLevel(CA_LORE_OF_ARMS)) ];
           e.EItem->swingCount++;
           if (e.EItem->swingCount > nSwings)
@@ -5231,7 +5231,7 @@ AfterEffects:
               !e.EItem2->isKnown(KN_MAGIC|KN_CURSE|KN_PLUS)) 
         if (e.EActor->HasAbility(CA_LORE_OF_ARMS))
         {
-          int8 nSwings = NeededSwings [ min(9,
+          int8 nSwings = NeededSwings [ min<int>(9,
             e.EActor->AbilityLevel(CA_LORE_OF_ARMS)) ];
           e.EItem2->swingCount++;
           if (e.remainingAmmo)
@@ -5360,7 +5360,7 @@ EvReturn Creature::Miss(EventInfo &e)
 	                e.EVictim->HasFeat(FT_GREAT_THROW) &&
 	                !e.EActor->isDead())
 	              ThrowDmg(EV_DAMAGE,AD_KNOC,Dice::Roll(1,3,
-	                max(0,e.EVictim->Mod(A_STR))), "Great Throw", e.EVictim, e.EActor);
+	                max<int>(0,e.EVictim->Mod(A_STR))), "Great Throw", e.EVictim, e.EActor);
   	        }
 
 		return DONE;
@@ -5482,9 +5482,9 @@ IgnoreMorality:;
             {
                 int16 mod, percent;
                 Armour *ar = (Armour*) e.EVictim->InSlot(SL_ARMOUR);
-                mod = max(0,e.EVictim->Mod(A_CON));
+                mod = max<int>(0,e.EVictim->Mod(A_CON));
                 percent = (e.EVictim->AbilityLevel(CA_TOUGH_AS_HELL) * 100) /
-                    (max(1,e.EVictim->ChallengeRating()) + ((!ar) ? 0 :
+                    (max<int>(1,e.EVictim->ChallengeRating()) + ((!ar) ? 0 :
                     ar->isGroup(WG_HARMOUR) ? 9 :
                     (ar->isGroup(WG_MARMOUR) ? 6 : 3)));
                 mod = (mod * percent) / 100;
@@ -5784,7 +5784,7 @@ NotWImmune:
                                             // so that armour can absorb small and medium blows instead of
                                             // just small blows. I think that's still in the realm of
                                             // believability.
-                                            Percent = AbsorbTable[min(e.vArm,16)][Col];
+                                            Percent = AbsorbTable[min<int>(e.vArm,16)][Col];
                                             int minAmount = 10 + e.vArm*2;
                                             if ((e.EItem && e.EItem->isItem() && 
                                                 e.EItem->HasIFlag(WT_PENETRATING)) ||
@@ -5815,7 +5815,7 @@ Absorbed:
                                                 return DONE;
                                             }
 
-                                            Percent = ArmourTable[min(e.vArm,32)][Col];
+                                            Percent = ArmourTable[min<int>(e.vArm,32)][Col];
                                             if (e.EItem && e.EItem->isItem() && 
                                                 e.EItem->HasIFlag(WT_PENETRATING))
                                                 Percent /= 2;
@@ -5860,7 +5860,7 @@ Absorbed:
                                                     if (e.vDef > e.vHit + 19)
                                                         e.vDefRoll -= 1;
 
-                                                    e.vDefRoll = max(1,e.vDefRoll);
+                                                    e.vDefRoll = max<int>(1,e.vDefRoll);
 
                                                     e.aDmg = max(1, (e.aDmg*e.vDefRoll)/6);
                                                     e.isDefRoll = true;
@@ -6250,7 +6250,7 @@ WoundIgnored:
                                         }
                                         if (e.AType == A_BITE && e.EActor && !e.EActor->isMType(MA_UNDEAD))
                                             subtype |= SA_POISON;
-                                        e.vDmg =  max(1,e.Dmg.Roll());
+                                        e.vDmg =  max<int>(1,e.Dmg.Roll());
                                         e.vDmg -= AbilityLevel(CA_STRONG_SOUL);
 
                                         if (e.vDmg <= 0) {
@@ -6337,7 +6337,7 @@ WoundIgnored:
                                                 // ... :-) 
                                                 e.EVictim->GainPermStati(ADJUST_DMG,NULL,SS_ATTK,A_AID,
                                                 -(max(1,e.vDmg / max(1,e.EVictim->ChallengeRating() * 5))));
-                                            lv = max(1,e.EVictim->ChallengeRating());
+                                            lv = max<int>(1,e.EVictim->ChallengeRating());
                                             lv += e.EVictim->SumStatiMag(ADJUST_DMG,A_AID);
                                             if (lv <= 0)
                                                 ReThrow(EV_DEATH,e);
@@ -6809,7 +6809,7 @@ EvReturn Creature::PDamage(EventInfo &e)
            comes from hallucinatory terrain -- but it's still good because
            GetStatiVal will return -1, which includes IL_SPECTRAL, and all
            terrain illusions are assumed to be spectral by default. */
-        e.EVictim->SetStatiDur(ILLUS_DMG,-1,e.EActor, max(
+        e.EVictim->SetStatiDur(ILLUS_DMG,-1,e.EActor, max<int>(
            e.EVictim->GetStatiMag(ILLUS_DMG,-1,e.EActor), Dice::Roll(3,6) *
            ( e.EActor->GetStatiVal(ILLUSION) & IL_SPECTRAL ? 100 : 1 ) ) );    
         e.EVictim->cHP -= e.aDmg;
@@ -7683,7 +7683,7 @@ int16 Creature::WeaponSaveDC(Item *wp, int16 at)
       break;
       case WT_STUNNING: 
       case WT_KNOCKDOWN:
-        DC += Mod2(A_STR) + (int16)(min(wp->Weight() / (40 * wp->Quantity), 5) + ((ti->Size - SZ_MEDIUM) * 2));
+        DC += Mod2(A_STR) + min<int16_t>(wp->Weight() / (40 * wp->Quantity), 5) + ((ti->Size - SZ_MEDIUM) * 2);
         break; 
       default:  
         Error("Unknown type of Weapon Save DC");

--- a/src/Help.cpp
+++ b/src/Help.cpp
@@ -248,7 +248,7 @@ void HelpSpellIndex(String &helpText) {
                             continue;
                         it->iID = iID;
                         if (it->HasSpell(theGame->SpellNum(Spells[j]))) {
-                            dlev = min(TITEM(iID)->Level, dlev);
+                            dlev = min<int>(TITEM(iID)->Level, dlev);
                             s = *TITEM(it->iID)->GetMessages(MSG_STATINAME);
                             if (!s.GetLength()) {
                                 s = it->Name(0);
@@ -2120,7 +2120,7 @@ String & Monster::Describe(Player *p) {
         Format("<5>The <Str><Str><7> ('<%d>%c%c%c<7>')\n__", GLYPH_COLOUR_VALUE(tm->Image), LITERAL_CHAR, LITERAL_CHAR1(gid), LITERAL_CHAR2(gid)),
         isMType(MA_DRAGON) ? "(Adult) " : "", NAME(xID));
     for (i = 1; i != str.GetLength(); i++)
-        if (isalpha_(max(1, str[i])) && str[i - 1] == ' ')
+        if (isalpha_(max<int>(1, str[i])) && str[i - 1] == ' ')
             str.SetAt(i, toupper(str[i]));
 
     if (tm->Desc) {
@@ -2309,7 +2309,7 @@ String & Monster::Describe(Player *p) {
             if (sv & XBIT(i)) {
                 str += SaveNames[i];
                 if (mm->Kills > 50) {
-                    n = max(CR, 0) * 3 / 2;
+                    n = max<int>(CR, 0) * 3 / 2;
                     n += (tm->Attr[SaveAttrs[i]] - 10) / 2;
                     str += Format(" (%+d)", n);
                 }
@@ -2328,7 +2328,7 @@ String & Monster::Describe(Player *p) {
             if (!(sv & XBIT(i))) {
                 str += SaveNames[i];
                 if (mm->Kills > 50) {
-                    n = max(CR, 0) * 3 / 4;
+                    n = max<int>(CR, 0) * 3 / 4;
                     n += (tm->Attr[SaveAttrs[i]] - 10) / 2;
                     str += Format(" (%+d)", n);
                 }

--- a/src/Help.cpp
+++ b/src/Help.cpp
@@ -248,7 +248,7 @@ void HelpSpellIndex(String &helpText) {
                             continue;
                         it->iID = iID;
                         if (it->HasSpell(theGame->SpellNum(Spells[j]))) {
-                            dlev = min<int>(TITEM(iID)->Level, dlev);
+                            dlev = std::min<int>(TITEM(iID)->Level, dlev);
                             s = *TITEM(it->iID)->GetMessages(MSG_STATINAME);
                             if (!s.GetLength()) {
                                 s = it->Name(0);
@@ -2120,7 +2120,7 @@ String & Monster::Describe(Player *p) {
         Format("<5>The <Str><Str><7> ('<%d>%c%c%c<7>')\n__", GLYPH_COLOUR_VALUE(tm->Image), LITERAL_CHAR, LITERAL_CHAR1(gid), LITERAL_CHAR2(gid)),
         isMType(MA_DRAGON) ? "(Adult) " : "", NAME(xID));
     for (i = 1; i != str.GetLength(); i++)
-        if (isalpha_(max<int>(1, str[i])) && str[i - 1] == ' ')
+        if (isalpha_(std::max<int>(1, str[i])) && str[i - 1] == ' ')
             str.SetAt(i, toupper(str[i]));
 
     if (tm->Desc) {
@@ -2195,7 +2195,7 @@ String & Monster::Describe(Player *p) {
         str += List[lc - 1];
 
     if (!tm->HasFlag(M_NOGEN))
-        str += Format("%sat depths of %dm in an average dungeon", lc ? ", as well as " : "", max(10, CR * 10));
+        str += Format("%sat depths of %dm in an average dungeon", lc ? ", as well as " : "", std::max(10, CR * 10));
     else if (!lc)
         str += "only in very specific places";
 
@@ -2309,7 +2309,7 @@ String & Monster::Describe(Player *p) {
             if (sv & XBIT(i)) {
                 str += SaveNames[i];
                 if (mm->Kills > 50) {
-                    n = max<int>(CR, 0) * 3 / 2;
+                    n = std::max<int>(CR, 0) * 3 / 2;
                     n += (tm->Attr[SaveAttrs[i]] - 10) / 2;
                     str += Format(" (%+d)", n);
                 }
@@ -2328,7 +2328,7 @@ String & Monster::Describe(Player *p) {
             if (!(sv & XBIT(i))) {
                 str += SaveNames[i];
                 if (mm->Kills > 50) {
-                    n = max<int>(CR, 0) * 3 / 4;
+                    n = std::max<int>(CR, 0) * 3 / 4;
                     n += (tm->Attr[SaveAttrs[i]] - 10) / 2;
                     str += Format(" (%+d)", n);
                 }
@@ -3693,8 +3693,8 @@ String & Armour::Describe(Player *p) {
             Desc += Format("__<13>%s %+d<7>: On average, <11>%d%%<7> of attacks will be absorbed completely. Other blows will have <11>%d%%<7> of their damage pentrate on average.\n",
                 dmg_types[i],
                 val,
-                AbsorbTable[min(val,16)][2],
-                ArmourTable[min(val,32)][2]);
+                AbsorbTable[std::min(val,16)][2],
+                ArmourTable[std::min(val,32)][2]);
         }
 #endif
 

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -869,7 +869,7 @@ EvReturn Item::Event(EventInfo &e) {
                 ((Weapon *)e.EItem2)->DoQualityDmgSingle(e);
             if (e.EItem && e.EItem->isWeapon())  
                 ((Weapon *)e.EItem)->DoQualityDmgSingle(e);
-            e.EActor->MakeNoise(max(10 - (e.EActor->SkillLevel(SK_MOVE_SIL) / 2),1));
+            e.EActor->MakeNoise(std::max(10 - (e.EActor->SkillLevel(SK_MOVE_SIL) / 2),1));
             if (cHP <= 0) {
                 e.Died = true; 
                 e.EActor->RemoveStati(ACTING); 
@@ -948,7 +948,7 @@ void Player::IdentByTrial(Item *it, int16 Quality)
       IPrint("These must be <Str>!",(const char*)it->Name());
     else
       IPrint("This must be <Str>!",(const char*)it->Name(NA_A));
-    Exercise(A_INT,random(6)+max(1,it->ItemLevel()/2),EINT_IDENT,60);
+    Exercise(A_INT,random(6) + std::max(1,it->ItemLevel()/2),EINT_IDENT,60);
   }
 
 bool Item::allowedSlot(int16 slot, Creature *me)
@@ -1546,7 +1546,7 @@ EvReturn Item::Damage(EventInfo &e) {
                     2500, 5000 };
                 int16 Factor;
                 Factor = (ItemLevel() + 2) - e.EPActor->TotalLevel();
-                Factor = min<int>(Factor,10);
+                Factor = std::min<int>(Factor,10);
                 if (Factor >= 0) {
                     if (isType(T_POTION) || isType(T_SCROLL))
                         e.EActor->GainXP((GainedXP[Factor] * Percent) / 1000);
@@ -1694,7 +1694,7 @@ EvReturn Food::Eat(EventInfo &e)
     if (e.EActor->HasStati(HUNGER)) {
       full = e.EActor->GetStatiDur(HUNGER);
       if (e.EActor->HasAbility(CA_SLOW_METABOLISM))
-        e.EActor->SetStatiDur(HUNGER,-1,NULL,full + max(nut / 3,1));
+        e.EActor->SetStatiDur(HUNGER,-1,NULL,full + std::max(nut / 3,1));
       else  
         e.EActor->SetStatiDur(HUNGER,-1,NULL,full + nut);
       }
@@ -1710,7 +1710,7 @@ EvReturn Food::Eat(EventInfo &e)
         {
           DPrint(e,"You vomit!",
                    "The <EActor> vomits!");
-          e.EActor->SetStatiDur(HUNGER,-1,NULL,min(full/2,HUNGRY));
+          e.EActor->SetStatiDur(HUNGER,-1,NULL,std::min(full/2,HUNGRY));
           if (!confirm && e.EActor->yn("Stop eating?"))
                   goto StopEating;
           confirm = true; 
@@ -1831,7 +1831,7 @@ int16 Corpse::noDiseaseDC() {
     
     StatiIterNature(this,TEMPLATE)
         if (TTEM(S->eID)->TType & TM_UNDEAD)
-            baseDC = max<int>(baseDC,25);
+            baseDC = std::max<int>(baseDC,25);
     StatiIterEnd(this)
         
     hours = (theGame->Turn - TurnCreated) / HOUR_TURNS;
@@ -1935,8 +1935,8 @@ int16 Weapon::ParryVal(Creature *c, bool knownOnly)
     val += (sk-WS_PROFICIENT) * 2; /* if you're a grand master, do expect 'em */
   /* WW: Important: no matter how amazing you are, you're not going to be
    * parrying bullets with a rock in your hand. */
-  val = min(ti->u.w.ParryMod * 2,val); 
-  return max(0,val);
+  val = std::min(ti->u.w.ParryMod * 2,val);
+  return std::max(0,val);
 }
 
 bool Weapon::isBaneOf(Creature *c)
@@ -2001,7 +2001,7 @@ int16 Armour::ArmVal(int16 typ, bool knownOnly)
     else if (GetGroup() & WG_LARMOUR) val += 1; 
   } 
   if (HasQuality(IQ_ORCISH) || HasQuality(IQ_DWARVEN)) val += 1;
-  return max(0,val);
+  return std::max(0,val);
 }
 
 int16 Armour::CovVal(Creature *c, bool knownOnly) 
@@ -2084,7 +2084,7 @@ int16 Armour::PenaltyVal(Creature * c, bool for_skills)
     val = 0;
   if (for_skills && c && c->HasFeat(FT_ARMOUR_OPTIMIZATION))
     val = (val-2)/3; 
-  return min(0,val);
+  return std::min(0,val);
 }
 
 // ww: since things like adamant affect this and multiple places (e.g.,
@@ -2118,7 +2118,7 @@ int32 Item::GetGroup(void)
 int16 Armour::MaxDexBonus(Creature * c)
 {
   int pen = PenaltyVal(c,false);
-  return max(0, 9 + pen);
+  return std::max(0, 9 + pen);
 }
 
 uint32 Creature::ArmourType() {
@@ -2161,7 +2161,7 @@ int16 Item::PItemLevel(Creature *cr)
   {
     if (cr->HasStati(TRUE_SIGHT))
       return ItemLevel();
-    return max(ItemLevel(),GetStatiMag(MAGIC_AURA));
+    return std::max(ItemLevel(),GetStatiMag(MAGIC_AURA));
   }
 
 int16 Item::ItemLevel(bool bounded)
@@ -2181,7 +2181,7 @@ int16 Item::ItemLevel(bool bounded)
     else
       eff_lev = 0; 
 
-    return max(eff_lev,cost_lev);
+    return std::max(eff_lev,cost_lev);
   }
 
 int16 Weapon::ItemLevel(bool bounded)
@@ -2214,16 +2214,16 @@ int16 Weapon::ItemLevel(bool bounded)
             QPlus += QualityMods[j][1];
         }
 
-    //base += PlusLevels[min(22,QPlus)];
-    //base += min(22,(QPlus*150)/100);
-    base = min(22,(QPlus*100)/100);
+    //base += PlusLevels[std::min(22,QPlus)];
+    //base += std::min(22,(QPlus*150)/100);
+    base = std::min(22,(QPlus*100)/100);
     
     // a +5 sword with no other qualities should be level
     // 10, even though a +5 flaming sword is also level
     // 10, otherwise high-bonus swords are too easy for
     // dwarves and bards to make.
     if (bounded)
-      base = max<int>(base,Plus*2);
+      base = std::max<int>(base,Plus*2);
     
     return base;
   }
@@ -2249,15 +2249,15 @@ int16 Armour::ItemLevel(bool bounded)
             QPlus += AQualityMods[j][1];
         }
 
-    // base += PlusLevels[min(22,QPlus)];
-    base += min(22,(QPlus*150)/100);
+    // base += PlusLevels[std::min(22,QPlus)];
+    base += std::min(22,(QPlus*150)/100);
     
     // a +5 sword with no other qualities should be level
     // 10, even though a +5 flaming sword is also level
     // 10, otherwise high-bonus swords are too easy for
     // dwarves and bards to make.
     if (bounded)
-      base = max<int>(base,Plus*2);
+      base = std::max<int>(base,Plus*2);
     
     return base;
   }
@@ -2279,8 +2279,8 @@ int16 QItem::ItemLevel(bool bounded)
             QPlus += AQualityMods[j][1];
         }
 
-    // base += PlusLevels[min(22,QPlus)];
-    base += min(22,(QPlus*150)/100);
+    // base += PlusLevels[std::min(22,QPlus)];
+    base += std::min(22,(QPlus*150)/100);
     return base;
   }
 
@@ -2797,12 +2797,12 @@ int16 Weapon::Size(Creature * wield)
   {
     int sofar = TITEM(iID)->Size; 
     if (HasQuality(IQ_FEATHERLIGHT) && wield)
-      sofar = max(SZ_TINY,sofar - 1);
+      sofar = std::max(SZ_TINY,sofar - 1);
     if (wield && wield->HasFeat(FT_SPEAR_AND_SHIELD) && 
         wield->InSlot(SL_READY) &&
         wield->InSlot(SL_READY)->isType(T_SHIELD) && 
         isGroup(WG_SPEARS|WG_LANCES|WG_POLEARMS))
-      sofar = max(SZ_TINY,sofar - 1);
+      sofar = std::max(SZ_TINY,sofar - 1);
     return sofar; 
   }
 
@@ -2834,7 +2834,7 @@ int16 Weapon::RangeInc(Creature *cr)
     if (!(TITEM(iID)->Group & WG_THROWN))
       if (!isType(T_BOW))
         return 0;      
-    rinc = max<int>( TITEM(iID)->u.w.RangeInc, 1 ) ;
+    rinc = std::max<int>( TITEM(iID)->u.w.RangeInc, 1 ) ;
     if (HasQuality(WQ_DISTANCE))
       rinc *= 2; 
     switch (cr->WepSkill(this)) {

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -1546,7 +1546,7 @@ EvReturn Item::Damage(EventInfo &e) {
                     2500, 5000 };
                 int16 Factor;
                 Factor = (ItemLevel() + 2) - e.EPActor->TotalLevel();
-                Factor = min(Factor,10);
+                Factor = min<int>(Factor,10);
                 if (Factor >= 0) {
                     if (isType(T_POTION) || isType(T_SCROLL))
                         e.EActor->GainXP((GainedXP[Factor] * Percent) / 1000);
@@ -1831,7 +1831,7 @@ int16 Corpse::noDiseaseDC() {
     
     StatiIterNature(this,TEMPLATE)
         if (TTEM(S->eID)->TType & TM_UNDEAD)
-            baseDC = max(baseDC,25);
+            baseDC = max<int>(baseDC,25);
     StatiIterEnd(this)
         
     hours = (theGame->Turn - TurnCreated) / HOUR_TURNS;
@@ -2223,7 +2223,7 @@ int16 Weapon::ItemLevel(bool bounded)
     // 10, otherwise high-bonus swords are too easy for
     // dwarves and bards to make.
     if (bounded)
-      base = max(base,Plus*2);
+      base = max<int>(base,Plus*2);
     
     return base;
   }
@@ -2257,7 +2257,7 @@ int16 Armour::ItemLevel(bool bounded)
     // 10, otherwise high-bonus swords are too easy for
     // dwarves and bards to make.
     if (bounded)
-      base = max(base,Plus*2);
+      base = max<int>(base,Plus*2);
     
     return base;
   }
@@ -2834,7 +2834,7 @@ int16 Weapon::RangeInc(Creature *cr)
     if (!(TITEM(iID)->Group & WG_THROWN))
       if (!isType(T_BOW))
         return 0;      
-    rinc = max ( TITEM(iID)->u.w.RangeInc, 1 ) ;
+    rinc = max<int>( TITEM(iID)->u.w.RangeInc, 1 ) ;
     if (HasQuality(WQ_DISTANCE))
       rinc *= 2; 
     switch (cr->WepSkill(this)) {

--- a/src/Magic.cpp
+++ b/src/Magic.cpp
@@ -127,7 +127,7 @@ int16 Creature::SpellDmgBonus(rID eID)
           that has AI_WIZARDRY/AI_SORCERY as a spell, even if it's,
           say, a staff spell or cleric spell. Not technically
           correct, but not a huge deal. */
-        db += max(0,Mod(A_WIS));
+        db += max<int>(0,Mod(A_WIS));
       }
     return db;
   } 
@@ -475,7 +475,7 @@ bool Magic::isTarget(EventInfo &_e, Thing *t) {
       else if (te->ef.aval == AR_POISON || te->ef.aval == AR_DISEASE)
           e.vCasterLev = te->Level;
       else if (sp_flags & SP_INNATE) 
-          e.vCasterLev = max(1,e.EActor->ChallengeRating());
+          e.vCasterLev = max<int>(1,e.EActor->ChallengeRating());
       else
           e.vCasterLev = (int8)e.EActor->CasterLev();
 
@@ -493,7 +493,7 @@ bool Magic::isTarget(EventInfo &_e, Thing *t) {
       }
 
       if (e.EItem && e.EItem->isItem())
-          e.vAlchemy = max(10,e.EItem->GetStatiMag(ALCHEMY_LEV));
+          e.vAlchemy = max<int>(10,e.EItem->GetStatiMag(ALCHEMY_LEV));
 
       if (e.effIllusion && !(e.illFlags & IL_SHADE))
           if (e.EActor->isPlayer())
@@ -560,7 +560,7 @@ bool Magic::isTarget(EventInfo &_e, Thing *t) {
       }
 
       if (e.MM & MM_MAXIMIZE)
-          e.vDmg = max(0,e.Dmg.Number) * abs(e.Dmg.Sides) + e.Dmg.Bonus;
+          e.vDmg = max<int>(0,e.Dmg.Number) * abs(e.Dmg.Sides) + e.Dmg.Bonus;
       else {
           if (e.Dmg.Sides < 0)
               e.Dmg.Sides = -e.Dmg.Sides;
@@ -698,7 +698,7 @@ Nothing:
 
           e.isFirstBlastXY = true;
 
-          if (e.isActivation != te->HasFlag(EF_ACTIVATE+min(e.efNum,4)))
+          if (e.isActivation != te->HasFlag(EF_ACTIVATE+min<int>(e.efNum,4)))
               { e.efNum++; continue; }
 
           if (te->HasFlag(EF_PERIODIC) && !e.isPeriodic) {                                         
@@ -1017,7 +1017,7 @@ DisbeliefMessageDone:
         /* Set EMagic to the current effect component */
         e.EMagic = te->Vals(e.efNum);
 
-        if (e.isActivation != te->HasFlag(EF_ACTIVATE+min(e.efNum,4)))
+        if (e.isActivation != te->HasFlag(EF_ACTIVATE+min<int>(e.efNum,4)))
             goto SkipSegment;
 
         e.Immune = e.MagicRes || doResistDeath || !isTarget(e,e.ETarget);
@@ -1412,7 +1412,7 @@ EvReturn Magic::ABarrier(EventInfo &e)
     if (e.MM & MM_ENLARGE)
       lim = max(e.vRadius*2,20);
     else
-      lim = max(e.vRadius,10);
+      lim = max<int>(e.vRadius,10);
 
     while ((!stop1) || (!stop2)) {
       if (!stop1) {
@@ -1644,7 +1644,7 @@ EvReturn Magic::ABallBeamBolt(EventInfo &e)
   // minimum range for wand beams ...
   if (isBeam && e.EItem && 
       (e.EItem->isType(T_WAND) || e.EItem->isType(T_POTION)))
-    e.vRange = max(5,e.vRange);
+    e.vRange = max<int>(5,e.vRange);
   
   // map overlay 
   Map &m = *(e.EActor->m);
@@ -2114,7 +2114,7 @@ void Magic::PredictVictimsOfBallBeamBolt(EventInfo &e,
   // minimum range for wand beams ...
   if (isBeam && e.EItem && 
       (e.EItem->isType(T_WAND) || e.EItem->isType(T_POTION)))
-    e.vRange = max(5,e.vRange);
+    e.vRange = max<int>(5,e.vRange);
 
   // map overlay 
   Map &m = *(e.EActor->m);
@@ -3070,7 +3070,7 @@ int16 Creature::SpellRating(rID eID, uint32 mm, bool perceived)
     if (Chance > 50 && (mm & MM_SURE))
       return 100;
 
-    return max(2,min((uint16)98,Chance));
+    return max(2,min<int>((uint16)98,Chance));
   }
 
 int16 p_base, p_int, p_lev, p_conc,
@@ -3155,7 +3155,7 @@ int16 Character::SpellRating(rID eID, uint32 mm, bool perceived)
          schools that the spell belongs to. */
       for(j = 0;j!=9;j++)
         if (TEFF(eID)->Schools & XBIT(j))
-          p_spec = max(p_spec,SpecialistTable[i][j]);
+          p_spec = max<int>(p_spec,SpecialistTable[i][j]);
 
       if (p_spec == -50)
         p_spec = 0;
@@ -3166,7 +3166,7 @@ int16 Character::SpellRating(rID eID, uint32 mm, bool perceived)
        druidic Evocations when you become an Illusionist, but you do
        get better at shared mage/druid illusions. */
     if (Spells[sp] & (SP_DIVINE|SP_BARDIC|SP_PRIMAL|SP_SORCERY))
-      p_spec = max(p_spec,0);
+      p_spec = max<int>(p_spec,0);
     
 
     int16 *at;
@@ -3215,13 +3215,13 @@ int16 Character::SpellRating(rID eID, uint32 mm, bool perceived)
 
     Chance = p_base + p_int + p_lev + p_meta + p_spec + p_calc + p_circ + p_conc;
 
-    if (Chance > max(90,p_base))
-      Chance = max(90,p_base) + ((Chance - max(90,p_base)) / 5);
+    if (Chance > max<int>(90,p_base))
+      Chance = max<int>(90,p_base) + ((Chance - max<int>(90,p_base)) / 5);
 
     if (Chance > 50 && (mm & MM_SURE))
       return 100;
 
-    return max(2,min((uint16)100,Chance));
+    return max(2,min<int>((uint16)100,Chance));
 
   }
   
@@ -3270,7 +3270,7 @@ int16 Creature::getSpellDC(rID spID, bool isTrick, bool isHeight)
     dc_beguile = 0;
     if (HasAbility(CA_BEGUILING_MAGIC))
       if (TEFF(spID)->HasFlag(EF_MENTAL))
-        dc_beguile = max(0,Mod(A_CHA));
+        dc_beguile = max<int>(0,Mod(A_CHA));
       
     dc_trick = isTrick ? 8 : 0;
     dc_height = isHeight ? 4 : 0;
@@ -3313,7 +3313,7 @@ int16 Creature::getSpellMana(rID spID, uint32 MM, int16 *specMod2)
       {
         mult = 2 + MMFeatLevels(MM);
         mCost = (mCost * mult + 1) / 2;
-        mCost = max(mCost,TEFF(spID)->ManaCost + (3*(mult-2)));
+        mCost = max<int>(mCost,TEFF(spID)->ManaCost + (3*(mult-2)));
       }
 
     /* New rule -- specialist wizards suffer more for casting from thier
@@ -3332,14 +3332,14 @@ int16 Creature::getSpellMana(rID spID, uint32 MM, int16 *specMod2)
            schools that the spell belongs to. */
         for(j = 0;j!=9;j++)
           if (TEFF(spID)->Schools & XBIT(j)) 
-            specMod = max(specMod,SpecialistTable[sch][j]);
+            specMod = max<int>(specMod,SpecialistTable[sch][j]);
               
         if (specMod == -50)
           specMod = 0;
         }     
     if (isPlayer() && (thisp->Spells[sp] & 
           (SP_DIVINE|SP_BARDIC|SP_PRIMAL|SP_SORCERY)))
-      specMod = max(specMod,0);
+      specMod = max<int>(specMod,0);
 
     
     if (TEFF(spID)->Purpose & EP_BUFF)
@@ -3739,7 +3739,7 @@ EvReturn Item::ZapWand(EventInfo &e)
          schools that the spell belongs to. */
       for(int j = 0;j!=9;j++)
         if (TEFF(eID)->Schools & XBIT(j))
-          m = max(m,SpecialistTable[i][j]);
+          m = max<int>(m,SpecialistTable[i][j]);
 
       if (m > 0)
         SpecBonus = m / 5;

--- a/src/Magic.cpp
+++ b/src/Magic.cpp
@@ -127,7 +127,7 @@ int16 Creature::SpellDmgBonus(rID eID)
           that has AI_WIZARDRY/AI_SORCERY as a spell, even if it's,
           say, a staff spell or cleric spell. Not technically
           correct, but not a huge deal. */
-        db += max<int>(0,Mod(A_WIS));
+        db += std::max<int>(0,Mod(A_WIS));
       }
     return db;
   } 
@@ -464,7 +464,7 @@ bool Magic::isTarget(EventInfo &_e, Thing *t) {
           e.saveDC = (int8)e.EActor->getSpellDC(e.eID, e.isArcaneTrickery,(e.MM & MM_HEIGHTEN) == MM_HEIGHTEN);
 
       if (e.isItem && e.EItem && e.EItem->isType(T_SCROLL))
-          e.vCasterLev = max(TEFF(e.EItem->eID)->Level*2-1,e.EActor->SkillLevel(SK_DECIPHER) - 2); 
+          e.vCasterLev = std::max(TEFF(e.EItem->eID)->Level*2-1,e.EActor->SkillLevel(SK_DECIPHER) - 2);
 
       if (e.isItem && e.EItem && e.EItem->isItem())
           e.vCasterLev = (int8)e.EItem->ItemLevel();
@@ -475,7 +475,7 @@ bool Magic::isTarget(EventInfo &_e, Thing *t) {
       else if (te->ef.aval == AR_POISON || te->ef.aval == AR_DISEASE)
           e.vCasterLev = te->Level;
       else if (sp_flags & SP_INNATE) 
-          e.vCasterLev = max<int>(1,e.EActor->ChallengeRating());
+          e.vCasterLev = std::max<int>(1,e.EActor->ChallengeRating());
       else
           e.vCasterLev = (int8)e.EActor->CasterLev();
 
@@ -493,7 +493,7 @@ bool Magic::isTarget(EventInfo &_e, Thing *t) {
       }
 
       if (e.EItem && e.EItem->isItem())
-          e.vAlchemy = max<int>(10,e.EItem->GetStatiMag(ALCHEMY_LEV));
+          e.vAlchemy = std::max<int>(10,e.EItem->GetStatiMag(ALCHEMY_LEV));
 
       if (e.effIllusion && !(e.illFlags & IL_SHADE))
           if (e.EActor->isPlayer())
@@ -560,7 +560,7 @@ bool Magic::isTarget(EventInfo &_e, Thing *t) {
       }
 
       if (e.MM & MM_MAXIMIZE)
-          e.vDmg = max<int>(0,e.Dmg.Number) * abs(e.Dmg.Sides) + e.Dmg.Bonus;
+          e.vDmg = std::max<int>(0,e.Dmg.Number) * abs(e.Dmg.Sides) + e.Dmg.Bonus;
       else {
           if (e.Dmg.Sides < 0)
               e.Dmg.Sides = -e.Dmg.Sides;
@@ -698,7 +698,7 @@ Nothing:
 
           e.isFirstBlastXY = true;
 
-          if (e.isActivation != te->HasFlag(EF_ACTIVATE+min<int>(e.efNum,4)))
+          if (e.isActivation != te->HasFlag(EF_ACTIVATE+ std::min<int>(e.efNum,4)))
               { e.efNum++; continue; }
 
           if (te->HasFlag(EF_PERIODIC) && !e.isPeriodic) {                                         
@@ -1009,7 +1009,7 @@ DisbeliefMessageDone:
                     doResistDeath = true;
                     TPrint(e,"The <EVictim> shrugs off your death magic with sheer toughness!",
                         "You shrug off the <EActor>'s death magic with sheer toughness! (<Num> left).", 
-                        NULL, max(0,e.EVictim->Mod(A_CON)*2 - (count+1)));
+                        NULL, std::max(0,e.EVictim->Mod(A_CON)*2 - (count+1)));
                 }
             }
 
@@ -1017,7 +1017,7 @@ DisbeliefMessageDone:
         /* Set EMagic to the current effect component */
         e.EMagic = te->Vals(e.efNum);
 
-        if (e.isActivation != te->HasFlag(EF_ACTIVATE+min<int>(e.efNum,4)))
+        if (e.isActivation != te->HasFlag(EF_ACTIVATE + std::min<int>(e.efNum,4)))
             goto SkipSegment;
 
         e.Immune = e.MagicRes || doResistDeath || !isTarget(e,e.ETarget);
@@ -1410,9 +1410,9 @@ EvReturn Magic::ABarrier(EventInfo &e)
 
     stop1 = stop2 = false;
     if (e.MM & MM_ENLARGE)
-      lim = max(e.vRadius*2,20);
+      lim = std::max(e.vRadius*2,20);
     else
-      lim = max<int>(e.vRadius,10);
+      lim = std::max<int>(e.vRadius,10);
 
     while ((!stop1) || (!stop2)) {
       if (!stop1) {
@@ -1512,7 +1512,7 @@ EvReturn Magic::AField(EventInfo &e)
     if (e.MM & MM_ENLARGE)
       e.vRadius *= 2;
     else if (e.MM & MM_FOCUS)
-      e.vRadius = max(1,e.vRadius/2);
+      e.vRadius = std::max(1,e.vRadius/2);
     
     for(x = tx-e.vRadius; x <= tx+e.vRadius; x++)
       for(y = ty-e.vRadius; y <= ty+e.vRadius; y++)
@@ -1602,7 +1602,7 @@ EvReturn Magic::ABallBeamBolt(EventInfo &e)
   // ww: WarpCount 
   int16 WarpCount;
   if (e.MM & MM_WARP)
-    WarpCount = max(2,3+e.EActor->Mod(A_INT));
+    WarpCount = std::max(2,3+e.EActor->Mod(A_INT));
   else
     WarpCount = 0;
 
@@ -1644,7 +1644,7 @@ EvReturn Magic::ABallBeamBolt(EventInfo &e)
   // minimum range for wand beams ...
   if (isBeam && e.EItem && 
       (e.EItem->isType(T_WAND) || e.EItem->isType(T_POTION)))
-    e.vRange = max<int>(5,e.vRange);
+    e.vRange = std::max<int>(5,e.vRange);
   
   // map overlay 
   Map &m = *(e.EActor->m);
@@ -1927,7 +1927,7 @@ EvReturn Magic::ABallBeamBolt(EventInfo &e)
           e.EXVal = best->x;
           e.EYVal = best->y;
           e.isDir = false;
-          ti = max(0,tc-1);
+          ti = std::max(0,tc-1);
           goto NextChain;
         }
     }
@@ -2076,7 +2076,7 @@ void Magic::PredictVictimsOfBallBeamBolt(EventInfo &e,
   // ww: WarpCount 
   int16 WarpCount;
   if (e.MM & MM_WARP)
-    WarpCount = max(2,3+e.EActor->Mod(A_INT));
+    WarpCount = std::max(2,3+e.EActor->Mod(A_INT));
   else
     WarpCount = 0;
 
@@ -2114,7 +2114,7 @@ void Magic::PredictVictimsOfBallBeamBolt(EventInfo &e,
   // minimum range for wand beams ...
   if (isBeam && e.EItem && 
       (e.EItem->isType(T_WAND) || e.EItem->isType(T_POTION)))
-    e.vRange = max<int>(5,e.vRange);
+    e.vRange = std::max<int>(5,e.vRange);
 
   // map overlay 
   Map &m = *(e.EActor->m);
@@ -2296,7 +2296,7 @@ EvReturn Creature::Cast(EventInfo &e) {
     EvReturn res; Item *it; bool dmgFail, wasThreatened;
     int16 i, j, oHP, fc, sc; Creature *c; String MMStr;
     int16 castingTimeout = 
-        3000 / max(25,100+10*(1 + e.EActor->Mod(A_INT) -
+        3000 / std::max(25,100+10*(1 + e.EActor->Mod(A_INT) -
         TEFF(e.eID)->Level));
     int16 specMod; 
     Counterspeller csp[64]; int16 cc; EvReturn csr;
@@ -2702,7 +2702,7 @@ ContinueCasting:
     dmg_pen = 0;
     if (oHP > cHP) {
         dmg_pen = ((oHP-cHP)*300) / (mHP+GetAttr(A_THP));
-        dmg_pen = max(0,dmg_pen - ((ConcentBuffer() - (concentUsed + p_conc))*5));
+        dmg_pen = std::max(0,dmg_pen - ((ConcentBuffer() - (concentUsed + p_conc))*5));
         rating -= dmg_pen;
     }  
 
@@ -2850,7 +2850,7 @@ EvReturn Creature::Invoke(EventInfo &e)
 
 
     if (TEFF(e.eID)->Purpose & EP_BUFF && HasFeat(FT_MYSTIC_PREPARATION)) {
-      mCost = max( (mCost-2), 1);
+      mCost = std::max( (mCost-2), 1);
     }
     LoseMana(mCost,TEFF(e.eID)->HasFlag(EF_LOSEMANA));
     } 
@@ -2957,12 +2957,12 @@ EvReturn Creature::Counterspell(EventInfo &e, Counterspeller *csp) {
                 if (TEFF(xID)->Level >= lv)
                     if (TEFF(xID)->Schools & TEFF(e.eID)->Schools & (SC_ABJ|SC_ARC|SC_DIV|SC_ENC|SC_EVO|SC_ILL|SC_NEC|SC_THA|SC_WEA))
                         if (csID == 0 || TEFF(xID)->ManaCost < TEFF(csID)->ManaCost) {
-                            csID = xID; mCost = max(TEFF(csID)->ManaCost, TEFF(e.eID)->ManaCost);
+                            csID = xID; mCost = std::max(TEFF(csID)->ManaCost, TEFF(e.eID)->ManaCost);
                         }
 
         if (!csID)
             if ((csp[i].cr->getSpellFlags(dispID) & SP_KNOWN)) {
-                isDispel = true; mCost = max(TEFF(dispID)->ManaCost, TEFF(e.eID)->ManaCost);
+                isDispel = true; mCost = std::max(TEFF(dispID)->ManaCost, TEFF(e.eID)->ManaCost);
             }
 
         if (!csID)
@@ -3021,7 +3021,7 @@ Counterspelled:
         "The <EActor> counters your spell with <9><Res><7>.",
         "The <EActor> mutters a quick counterspell!", csID);
 
-    csp[i].cr->Timeout += max(3, (isDispel ? 20 : 15) - csp[i].cr->SkillLevel(SK_SPELLCRAFT));
+    csp[i].cr->Timeout += std::max(3, (isDispel ? 20 : 15) - csp[i].cr->SkillLevel(SK_SPELLCRAFT));
     LoseMana(mCost);
 
     if (csp[i].cr->HasFeat(FT_REFLECTIVE_COUNTERSPELL))
@@ -3060,7 +3060,7 @@ int16 Creature::SpellRating(rID eID, uint32 mm, bool perceived)
        close enough for now. */
     if ( TEFF(eID)->HasSource(AI_THEURGY) || 
          TEFF(eID)->HasSource(AI_DRUIDIC) )
-      Chance += max(Attr[A_ARC],Attr[A_DIV])*5;
+      Chance += std::max(Attr[A_ARC],Attr[A_DIV])*5;
     else
       Chance += Attr[A_ARC]*5;
 
@@ -3070,7 +3070,7 @@ int16 Creature::SpellRating(rID eID, uint32 mm, bool perceived)
     if (Chance > 50 && (mm & MM_SURE))
       return 100;
 
-    return max(2,min<int>((uint16)98,Chance));
+    return std::max(2, std::min<int>((uint16)98,Chance));
   }
 
 int16 p_base, p_int, p_lev, p_conc,
@@ -3155,7 +3155,7 @@ int16 Character::SpellRating(rID eID, uint32 mm, bool perceived)
          schools that the spell belongs to. */
       for(j = 0;j!=9;j++)
         if (TEFF(eID)->Schools & XBIT(j))
-          p_spec = max<int>(p_spec,SpecialistTable[i][j]);
+          p_spec = std::max<int>(p_spec,SpecialistTable[i][j]);
 
       if (p_spec == -50)
         p_spec = 0;
@@ -3166,7 +3166,7 @@ int16 Character::SpellRating(rID eID, uint32 mm, bool perceived)
        druidic Evocations when you become an Illusionist, but you do
        get better at shared mage/druid illusions. */
     if (Spells[sp] & (SP_DIVINE|SP_BARDIC|SP_PRIMAL|SP_SORCERY))
-      p_spec = max<int>(p_spec,0);
+      p_spec = std::max<int>(p_spec,0);
     
 
     int16 *at;
@@ -3207,21 +3207,21 @@ int16 Character::SpellRating(rID eID, uint32 mm, bool perceived)
         { p_circ = -40; ps_circ += "terrain/"; }
       }
     if (HasStati(MOUNTED) && isThreatened())
-      { p_circ -= max(0,40 - SkillLevel(SK_RIDE)*2);
+      { p_circ -= std::max(0,40 - SkillLevel(SK_RIDE)*2);
         ps_circ += "mounted/"; }
     
     concentLeft = ConcentBuffer() - concentUsed;
-    p_conc = min(abs(p_circ),concentLeft*5);
+    p_conc = std::min(abs(p_circ),concentLeft*5);
 
     Chance = p_base + p_int + p_lev + p_meta + p_spec + p_calc + p_circ + p_conc;
 
-    if (Chance > max<int>(90,p_base))
-      Chance = max<int>(90,p_base) + ((Chance - max<int>(90,p_base)) / 5);
+    if (Chance > std::max<int>(90,p_base))
+      Chance = std::max<int>(90,p_base) + ((Chance - std::max<int>(90,p_base)) / 5);
 
     if (Chance > 50 && (mm & MM_SURE))
       return 100;
 
-    return max(2,min<int>((uint16)100,Chance));
+    return std::max(2, std::min<int>((uint16)100,Chance));
 
   }
   
@@ -3270,7 +3270,7 @@ int16 Creature::getSpellDC(rID spID, bool isTrick, bool isHeight)
     dc_beguile = 0;
     if (HasAbility(CA_BEGUILING_MAGIC))
       if (TEFF(spID)->HasFlag(EF_MENTAL))
-        dc_beguile = max<int>(0,Mod(A_CHA));
+        dc_beguile = std::max<int>(0,Mod(A_CHA));
       
     dc_trick = isTrick ? 8 : 0;
     dc_height = isHeight ? 4 : 0;
@@ -3313,7 +3313,7 @@ int16 Creature::getSpellMana(rID spID, uint32 MM, int16 *specMod2)
       {
         mult = 2 + MMFeatLevels(MM);
         mCost = (mCost * mult + 1) / 2;
-        mCost = max<int>(mCost,TEFF(spID)->ManaCost + (3*(mult-2)));
+        mCost = std::max<int>(mCost,TEFF(spID)->ManaCost + (3*(mult-2)));
       }
 
     /* New rule -- specialist wizards suffer more for casting from thier
@@ -3332,14 +3332,14 @@ int16 Creature::getSpellMana(rID spID, uint32 MM, int16 *specMod2)
            schools that the spell belongs to. */
         for(j = 0;j!=9;j++)
           if (TEFF(spID)->Schools & XBIT(j)) 
-            specMod = max<int>(specMod,SpecialistTable[sch][j]);
+            specMod = std::max<int>(specMod,SpecialistTable[sch][j]);
               
         if (specMod == -50)
           specMod = 0;
         }     
     if (isPlayer() && (thisp->Spells[sp] & 
           (SP_DIVINE|SP_BARDIC|SP_PRIMAL|SP_SORCERY)))
-      specMod = max<int>(specMod,0);
+      specMod = std::max<int>(specMod,0);
 
     
     if (TEFF(spID)->Purpose & EP_BUFF)
@@ -3347,16 +3347,16 @@ int16 Creature::getSpellMana(rID spID, uint32 MM, int16 *specMod2)
         if (AbilityLevel(CA_PREPATORY_MAGIC))          
           {
             int16 percent = 100 - AbilityLevel(CA_PREPATORY_MAGIC)*5;
-            mCost = max( (mCost*percent)/100 , 1);
+            mCost = std::max( (mCost*percent)/100 , 1);
           }
         if (HasFeat(FT_MYSTIC_PREPARATION))
-          mCost = max( (mCost-2), 1);
+          mCost = std::max( (mCost-2), 1);
       }
       
     if (specMod < 0)
       mCost += (mCost * abs(specMod)) / 10;
     else if (specMod > 0)
-      mCost = max (1, mCost - ((mCost * abs(specMod)) / 50));
+      mCost = std::max(1, mCost - ((mCost * abs(specMod)) / 50));
 
     if (specMod2)
       *specMod2 = specMod;
@@ -3595,7 +3595,7 @@ EvReturn Item::ReadScroll(EventInfo &e)
         e.EActor->IdentByTrial(e.EItem);
 
 Failed:
-    e.EActor->Timeout += max(10,50 - cLevel*2);
+    e.EActor->Timeout += std::max(10,50 - cLevel*2);
 
     if (e.EActor->SpellRating(eID) <= 0)
       {
@@ -3672,7 +3672,7 @@ EvReturn Item::ZapWand(EventInfo &e)
       goto Nothing;
 
     int16 zappingTimeout = 
-            2000 / max(25,100+e.EActor->Mod(A_INT)*5);  
+            2000 / std::max(25,100+e.EActor->Mod(A_INT)*5);
     // ww: let's bring that INT mod into play here
     e.EActor->Timeout += zappingTimeout;
     e.EActor->AccessTime(e.EItem);
@@ -3692,7 +3692,7 @@ EvReturn Item::ZapWand(EventInfo &e)
           e.EActor->IPrint("You don't have enough mana.");
           return ABORT;
           }
-        if (e.EActor->cMana() >= max(1,Cost/2))
+        if (e.EActor->cMana() >= std::max(1,Cost/2))
           if ((e.EItem->isKnown(KN_PLUS|KN_MAGIC)) && e.EActor->yn("Fire it anyway?",true))
             {
               ThrowDmg(EV_DAMAGE,AD_NORM,Dice::Roll(TEFF(e.eID)->ManaCost - 
@@ -3721,8 +3721,8 @@ EvReturn Item::ZapWand(EventInfo &e)
         rollC = Dice::Roll(1,20);
     StatiIterEnd(e.EActor)
     
-    roll   = max(rollA,rollB);
-    roll   = max(roll ,rollC);
+    roll   = std::max(rollA,rollB);
+    roll   = std::max(roll ,rollC);
     Lev    = e.EItem->ItemLevel();
     SpecBonus = 0; 
     if (TEFF(eID)->HasFlag(EF_STAPLE))
@@ -3739,7 +3739,7 @@ EvReturn Item::ZapWand(EventInfo &e)
          schools that the spell belongs to. */
       for(int j = 0;j!=9;j++)
         if (TEFF(eID)->Schools & XBIT(j))
-          m = max<int>(m,SpecialistTable[i][j]);
+          m = std::max<int>(m,SpecialistTable[i][j]);
 
       if (m > 0)
         SpecBonus = m / 5;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -2026,11 +2026,11 @@ void Game::ListItemsByLevel()
                     (const char*)ItemNameFromEffect(r[i]) );
               else
                 list[c] = Format("  [%2d/%2d/%2d/%2d/%2d] %s\n",
-                    max(1,LevelAdjust(te->Level,0,1)),
-                    max(1,LevelAdjust(te->Level,0,2)),
-                    max(1,LevelAdjust(te->Level,0,3)),
-                    max(1,LevelAdjust(te->Level,0,4)),
-                    max(1,LevelAdjust(te->Level,0,5)),
+                    max<int>(1,LevelAdjust(te->Level,0,1)),
+                    max<int>(1,LevelAdjust(te->Level,0,2)),
+                    max<int>(1,LevelAdjust(te->Level,0,3)),
+                    max<int>(1,LevelAdjust(te->Level,0,4)),
+                    max<int>(1,LevelAdjust(te->Level,0,5)),
                     (const char*)ItemNameFromEffect(r[i]) );
 
               c++;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -15,6 +15,9 @@
 
 */
 
+// Prevent <windows.h> min/max definitions
+#define NOMINMAX
+
 #ifdef UNDEF_WIN32
 #include <windows.h>
 #include <Winbase.h>
@@ -309,7 +312,7 @@ FauxContinue:
         cDestroyQueue is emptied. */
         bool skip_delete = Opt(OPT_NO_FREE) != 0;
         while(DestroyCount && !skip_delete) {
-            memcpy(cDestroyQueue,DestroyQueue,sizeof(Thing*)*min(20048,DestroyCount+1));
+            memcpy(cDestroyQueue,DestroyQueue,sizeof(Thing*) * std::min(20048,DestroyCount+1));
             cDestroyCount = DestroyCount;
             DestroyCount = 0;            
             while (cDestroyCount) {
@@ -704,7 +707,7 @@ void Game::MonsterEvaluation(void)
               if(t->isCreature()) {
                 ((Creature*)t)->AoO =
                   ((Creature*)t)->HasFeat(FT_COMBAT_REFLEXES) ?
-                  max(1,1 + ((Creature*)t)->Mod2(A_DEX)) : 1;
+                    std::max(1,1 + ((Creature*)t)->Mod2(A_DEX)) : 1;
                 if (((Creature*)t)->HasAttk(A_GAZE))
                   ((Creature*)t)->DoGazeAttack();
                 if (((Creature*)t)->HasAttk(A_PROX) || 
@@ -1117,7 +1120,7 @@ void Game::MonsterEvaluationCR(void)
               if(t->isCreature()) {
                 ((Creature*)t)->AoO =
                   ((Creature*)t)->HasFeat(FT_COMBAT_REFLEXES) ?
-                  max(1,1 + ((Creature*)t)->Mod2(A_DEX)) : 1;
+                    std::max(1,1 + ((Creature*)t)->Mod2(A_DEX)) : 1;
                 if (((Creature*)t)->HasAttk(A_GAZE))
                   ((Creature*)t)->DoGazeAttack();
                 if (((Creature*)t)->HasAttk(A_PROX) || 
@@ -1542,7 +1545,7 @@ void Game::WeaponEvaluation(void)
               if(t->isCreature()) {
                 ((Creature*)t)->AoO =
                   ((Creature*)t)->HasFeat(FT_COMBAT_REFLEXES) ?
-                  max(1,1 + ((Creature*)t)->Mod2(A_DEX)) : 1;
+                    std::max(1,1 + ((Creature*)t)->Mod2(A_DEX)) : 1;
                 if (((Creature*)t)->HasAttk(A_GAZE))
                   ((Creature*)t)->DoGazeAttack();
                 if (((Creature*)t)->HasAttk(A_PROX) || 
@@ -2018,19 +2021,19 @@ void Game::ListItemsByLevel()
               
               if (IType[t] == AI_WAND)               
                 list[c] = Format("  [%2d/%2d/%2d/%2d/%2d] %s\n",
-                    max(1,LevelAdjust(te->Level,0,1)-2),
-                    max(1,LevelAdjust(te->Level,0,2)-2),
-                    max(1,LevelAdjust(te->Level,0,3)-2),
-                    max(1,LevelAdjust(te->Level,0,4)-2),
-                    max(1,LevelAdjust(te->Level,0,5)-2),
+                    std::max(1,LevelAdjust(te->Level,0,1)-2),
+                    std::max(1,LevelAdjust(te->Level,0,2)-2),
+                    std::max(1,LevelAdjust(te->Level,0,3)-2),
+                    std::max(1,LevelAdjust(te->Level,0,4)-2),
+                    std::max(1,LevelAdjust(te->Level,0,5)-2),
                     (const char*)ItemNameFromEffect(r[i]) );
               else
                 list[c] = Format("  [%2d/%2d/%2d/%2d/%2d] %s\n",
-                    max<int>(1,LevelAdjust(te->Level,0,1)),
-                    max<int>(1,LevelAdjust(te->Level,0,2)),
-                    max<int>(1,LevelAdjust(te->Level,0,3)),
-                    max<int>(1,LevelAdjust(te->Level,0,4)),
-                    max<int>(1,LevelAdjust(te->Level,0,5)),
+                    std::max<int>(1,LevelAdjust(te->Level,0,1)),
+                    std::max<int>(1,LevelAdjust(te->Level,0,2)),
+                    std::max<int>(1,LevelAdjust(te->Level,0,3)),
+                    std::max<int>(1,LevelAdjust(te->Level,0,4)),
+                    std::max<int>(1,LevelAdjust(te->Level,0,5)),
                     (const char*)ItemNameFromEffect(r[i]) );
 
               c++;

--- a/src/MakeLev.cpp
+++ b/src/MakeLev.cpp
@@ -213,8 +213,8 @@ int16 AdjustCR(int16 BaselineCR) {
     if (BaselineCR < 0)
         return BaselineCR;
     switch (theGame->GetPlayer(0)->Opt(OPT_DIFFICULTY)) {
-    case DIFF_EXPLORE:   return ExploreCR[min<int>(20, BaselineCR)];
-    case DIFF_TRAINING:  return ExploreCR[min<int>(20, BaselineCR)];
+    case DIFF_EXPLORE:   return ExploreCR[std::min<int>(20, BaselineCR)];
+    case DIFF_TRAINING:  return ExploreCR[std::min<int>(20, BaselineCR)];
     case DIFF_NIGHTMARE: return BaselineCR + 2;
     default: return BaselineCR;
     }
@@ -406,8 +406,8 @@ void Map::WriteWalls(Rect &r, rID regID) {
     FloorID = TREG(regID)->Floor;
     WallID = TREG(regID)->Walls;
 
-    for (x = max(1, r.x1 - 1); x < min(r.x2 + 2, sizeX - 1); x++)
-        for (y = max(1, r.y1 - 1); y < min(r.y2 + 2, sizeY - 1); y++)
+    for (x = std::max(1, r.x1 - 1); x < std::min(r.x2 + 2, sizeX - 1); x++)
+        for (y = std::max(1, r.y1 - 1); y < std::min(r.y2 + 2, sizeY - 1); y++)
             if (TerrainAt(x, y) != FloorID)
                 if (TerrainAt(x, y + 1) == FloorID || TerrainAt(x + 1, y) == FloorID ||
                     TerrainAt(x, y - 1) == FloorID || TerrainAt(x - 1, y) == FloorID ||
@@ -814,7 +814,7 @@ void Map::WriteMaze(Rect &r, rID regID, int16 inset_count, ...) {
         }
 
     /* Secret Doors */
-    n = min(7, Depth - 3);
+    n = std::min(7, Depth - 3);
     if (n <= 0)
         return;
 
@@ -864,7 +864,7 @@ void Map::WriteStreamer(Rect &r, uint8 sx, uint8 sy, Dir d, rID regID) {
     }
 
     if (TREG(regID)->HasFlag(RF_CHASM))
-        MWidth = max(4, MWidth + 1);
+        MWidth = std::max(4, MWidth + 1);
 
     rx = 2 + random(10);
     ry = 2 + random(10);
@@ -1159,7 +1159,7 @@ void Map::WriteMap(Rect &r, rID regID) {
                 maxlev = DepthCR + (ch - '0') * 2; /* Later, by map constants */
                 while (((50 - mLuck * 3) > (random(100) + 1)))
                     maxlev++;
-                mID = theGame->GetMonID(PUR_DUNGEON, (int8)max(0, maxlev - 5), (int8)maxlev, (int8)DepthCR);
+                mID = theGame->GetMonID(PUR_DUNGEON, (int8)std::max(0, maxlev - 5), (int8)maxlev, (int8)DepthCR);
                 if (mID) {
                     mn = new Monster(mID);
                     mn->PartyID = PartyID;
@@ -2359,7 +2359,7 @@ Reselect:
     // Sum up all the room type weightings.
     weighting_sum = 0;
     for (i = 0; RM_Weights[i * 2 + 1]; i++)
-        weighting_sum += max<int16_t>(0, (int16)RM_Weights[i * 2 + 1]);
+        weighting_sum += std::max<int16_t>(0, (int16)RM_Weights[i * 2 + 1]);
 
     // If all room types are used up, free them all up for reuse.
     if (weighting_sum == 0) {
@@ -2379,7 +2379,7 @@ Reselect:
     // Pick a room type, leave the selection index in 'i'.
     c = random(weighting_sum);
     for (i = 0; RM_Weights[i * 2 + 1]; i++) {
-        weight = max<int16_t>(0, (int16)RM_Weights[i * 2 + 1]);
+        weight = std::max<int16_t>(0, (int16)RM_Weights[i * 2 + 1]);
         ASSERT(weight != -1)
             if (c < weight) {
                 RM_WeightIndex = i * 2;
@@ -2476,8 +2476,8 @@ DoBasicRoom:
         xe.cRoom = r;
         break;
     case RM_LCIRCLE:
-        sx = (int16)max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(5) + 5));
-        sy = (int16)max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(5) + 5));
+        sx = (int16)std::max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(5) + 5));
+        sy = (int16)std::max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(5) + 5));
         if (TREG(regID)->HasFlag(RF_ODD_WIDTH) && !(sx % 2))
             sx++;
         if (TREG(regID)->HasFlag(RF_ODD_HEIGHT) && !(sy % 2))
@@ -2488,8 +2488,8 @@ DoBasicRoom:
         xe.cRoom = r;
         break;
     case RM_LARGE:
-        sx = (int16)max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(8) + 2));
-        sy = (int16)max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(8) + 2));
+        sx = (int16)std::max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(8) + 2));
+        sy = (int16)std::max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(8) + 2));
         if (TREG(regID)->HasFlag(RF_ODD_WIDTH) && !(sx % 2))
             sx++;
         if (TREG(regID)->HasFlag(RF_ODD_HEIGHT) && !(sy % 2))
@@ -2499,8 +2499,8 @@ DoBasicRoom:
         xe.cRoom = r;
         break;
     case RM_MAZE:
-        sx = (int16)max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(8) + 2));
-        sy = (int16)max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(8) + 2));
+        sx = (int16)std::max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(8) + 2));
+        sy = (int16)std::max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(8) + 2));
         r = cPanel.PlaceWithinSafely((uint8)sx, (uint8)sy);
         WriteMaze(r, regID);
         xe.cRoom = r;
@@ -2628,8 +2628,8 @@ DoBasicRoom:
     case RM_OCTAGON:
         sx = (int16)(Con[ROOM_MINX] + random((int16)(Con[ROOM_MAXX] - Con[ROOM_MINX])) + 3);
         sy = (int16)(Con[ROOM_MINY] + random((int16)(Con[ROOM_MAXY] - Con[ROOM_MINY])) + 3);
-        sx = max<int>(sx, 9);
-        sy = max<int>(sy, 9);
+        sx = std::max<int>(sx, 9);
+        sy = std::max<int>(sy, 9);
         if (TREG(regID)->HasFlag(RF_ODD_WIDTH) && !(sx % 2)) { if (sx == Con[ROOM_MAXX]) sx--; else sx++; }
         if (TREG(regID)->HasFlag(RF_ODD_HEIGHT) && !(sy % 2)) { if (sx == Con[ROOM_MAXY]) sy--; else sy++; }
         r = cPanel.PlaceWithinSafely((uint8)sx, (uint8)sy);
@@ -2679,8 +2679,8 @@ DoBasicRoom:
     case RM_CASTLE:
         IndividualRooms = random(2) ? true : false;
         /* Later, Castles will have corridors *and* rooms. */
-        sx = (int16)max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(6) + 2));
-        sy = (int16)max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(6) + 2));
+        sx = (int16)std::max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(6) + 2));
+        sy = (int16)std::max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(6) + 2));
         r = cPanel.PlaceWithinSafely((uint8)sx, (uint8)sy);
         WriteRoom(r, regID);
         cRectPop = 0;
@@ -2725,8 +2725,8 @@ DoBasicRoom:
         xe.cRoom = r;
         break;
     case RM_CROSS:
-        sx = (int16)max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(8) + 5));
-        sy = (int16)max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(8) + 5));
+        sx = (int16)std::max(Con[PANEL_SIZEX] / 2, Con[PANEL_SIZEX] - (random(8) + 5));
+        sy = (int16)std::max(Con[PANEL_SIZEY] / 2, Con[PANEL_SIZEY] - (random(8) + 5));
         if (TREG(regID)->HasFlag(RF_ODD_WIDTH) && !(sx % 2)) { if (sx == Con[ROOM_MAXX]) sx--; else sx++; }
         if (TREG(regID)->HasFlag(RF_ODD_HEIGHT) && !(sy % 2)) { if (sx == Con[ROOM_MAXY]) sy--; else sy++; }
         r = cPanel.PlaceWithinSafely((uint8)sx, (uint8)sy);
@@ -2743,8 +2743,8 @@ DoBasicRoom:
         WriteWalls(cPanel, regID);
         break;
     case RM_DOUBLE:
-        //sx = max(Con[PANEL_SIZEX]/2,Con[PANEL_SIZEX] - (random(8)+5));
-        //sy = max(Con[PANEL_SIZEY]/2,Con[PANEL_SIZEY] - (random(8)+5));
+        //sx = std::max(Con[PANEL_SIZEX]/2,Con[PANEL_SIZEX] - (random(8)+5));
+        //sy = std::max(Con[PANEL_SIZEY]/2,Con[PANEL_SIZEY] - (random(8)+5));
         sx = (int16)(Con[ROOM_MINX] + random((int16)(Con[ROOM_MAXX] - Con[ROOM_MINX])) + 3);
         sy = (int16)(Con[ROOM_MINY] + random((int16)(Con[ROOM_MAXY] - Con[ROOM_MINY])) + 3);
         if (TREG(regID)->HasFlag(RF_ODD_WIDTH) && !(sx % 2)) { if (sx == Con[ROOM_MAXX]) sx--; else sx++; }
@@ -3230,7 +3230,7 @@ SplatterByDefault :
             it->Remove(true);
     } else if (random(100) + 1 < 50) {
         /* Generate a poor item */
-        it = Item::GenItem(0, dID, max(0, DepthCR / 2 - 4), 10, DungeonItems);
+        it = Item::GenItem(0, dID, std::max(0, DepthCR / 2 - 4), 10, DungeonItems);
         if (it) {
             RANDOM_OPEN_NEAR_SOLID;
             if (x != -1)

--- a/src/MakeLev.cpp
+++ b/src/MakeLev.cpp
@@ -213,8 +213,8 @@ int16 AdjustCR(int16 BaselineCR) {
     if (BaselineCR < 0)
         return BaselineCR;
     switch (theGame->GetPlayer(0)->Opt(OPT_DIFFICULTY)) {
-    case DIFF_EXPLORE:   return ExploreCR[min(20, BaselineCR)];
-    case DIFF_TRAINING:  return ExploreCR[min(20, BaselineCR)];
+    case DIFF_EXPLORE:   return ExploreCR[min<int>(20, BaselineCR)];
+    case DIFF_TRAINING:  return ExploreCR[min<int>(20, BaselineCR)];
     case DIFF_NIGHTMARE: return BaselineCR + 2;
     default: return BaselineCR;
     }
@@ -2359,7 +2359,7 @@ Reselect:
     // Sum up all the room type weightings.
     weighting_sum = 0;
     for (i = 0; RM_Weights[i * 2 + 1]; i++)
-        weighting_sum += max(0, (int16)RM_Weights[i * 2 + 1]);
+        weighting_sum += max<int16_t>(0, (int16)RM_Weights[i * 2 + 1]);
 
     // If all room types are used up, free them all up for reuse.
     if (weighting_sum == 0) {
@@ -2379,7 +2379,7 @@ Reselect:
     // Pick a room type, leave the selection index in 'i'.
     c = random(weighting_sum);
     for (i = 0; RM_Weights[i * 2 + 1]; i++) {
-        weight = max(0, (int16)RM_Weights[i * 2 + 1]);
+        weight = max<int16_t>(0, (int16)RM_Weights[i * 2 + 1]);
         ASSERT(weight != -1)
             if (c < weight) {
                 RM_WeightIndex = i * 2;
@@ -2628,8 +2628,8 @@ DoBasicRoom:
     case RM_OCTAGON:
         sx = (int16)(Con[ROOM_MINX] + random((int16)(Con[ROOM_MAXX] - Con[ROOM_MINX])) + 3);
         sy = (int16)(Con[ROOM_MINY] + random((int16)(Con[ROOM_MAXY] - Con[ROOM_MINY])) + 3);
-        sx = max(sx, 9);
-        sy = max(sy, 9);
+        sx = max<int>(sx, 9);
+        sy = max<int>(sy, 9);
         if (TREG(regID)->HasFlag(RF_ODD_WIDTH) && !(sx % 2)) { if (sx == Con[ROOM_MAXX]) sx--; else sx++; }
         if (TREG(regID)->HasFlag(RF_ODD_HEIGHT) && !(sy % 2)) { if (sx == Con[ROOM_MAXY]) sy--; else sy++; }
         r = cPanel.PlaceWithinSafely((uint8)sx, (uint8)sy);

--- a/src/Managers.cpp
+++ b/src/Managers.cpp
@@ -426,7 +426,7 @@ DoneAB:
                 p->QuickKeys[sp-'0'].Type = QKY_SPELL;
                 goto ProcessSpells;
             }
-            if (sp >= 'a' && sp <= min('z',ch-1)) {
+            if (sp >= 'a' && sp <= min<int>('z',ch-1)) {
                 Restore();
                 SetMode(oldMode);
                 return Spells[sp - 'a'];
@@ -1692,7 +1692,7 @@ Recount:
                 PutChar(0, sl + ln, '>');
                 break;
             case KY_CMD_SOUTH:
-                if (ln >= min(j, SKILLS_SHOWN)) {
+                if (ln >= min<int>(j, SKILLS_SHOWN)) {
                     if (offset + SKILLS_SHOWN < (SK_LAST - 1)) {
                         offset++;
                         goto ReDraw;
@@ -1887,7 +1887,7 @@ void TextTerm::OptionManager(int16 start_cat) {
             }
         } else if (!n)
             Write(4, 4, "[No Options Yet]");
-        else for (i = Off; i < min(Off + (WinSizeY() - 13), n); i++) {
+        else for (i = Off; i < min<int>(Off + (WinSizeY() - 13), n); i++) {
             Color(i == c ? EMERALD : GREY);
             Write(4, 4 + (i - Off), OptionList[OptsShown[i]].Name);
             Color(YELLOW);

--- a/src/Managers.cpp
+++ b/src/Managers.cpp
@@ -51,7 +51,7 @@ int16 TextTerm::SpellManager(int16 Purpose) {
     }
 Redraw:
     Save();
-    SizeWin(WIN_SPELLS,-1,5,-1,5+min(11 + NumSpells,(sizeY*39)/50));
+    SizeWin(WIN_SPELLS,-1,5,-1,5+std::min(11 + NumSpells,(sizeY*39)/50));
     SetWin(WIN_SPELLS); 
     SizeWin(WIN_CUSTOM,2,WinBottom()-8,WinSizeX()-2,WinBottom()-3);
 
@@ -162,7 +162,7 @@ ProcessSpells:
                     String save_string;
                     int KY_color = Key ? -YELLOW : -GREY; 
                     int name_color = ((p->Spells[i] & SP_DOMAIN) ? -PURPLE : -GREY);
-                    int time_cost = 3000 / max(25,100+10*(1 + e.EActor->Mod(A_INT) -
+                    int time_cost = 3000 / std::max(25,100+10*(1 + e.EActor->Mod(A_INT) -
                         TEFF(e.eID)->Level));
 
 
@@ -197,13 +197,13 @@ ProcessSpells:
 
                     int savedc = 10 + TEFF(e.eID)->Level;
                     if ((p->Spells[i] & (SP_ARCANE|SP_INNATE))) 
-                        savedc = max(savedc,10+TEFF(e.eID)->Level+e.EActor->Mod(A_INT));
+                        savedc = std::max(savedc,10+TEFF(e.eID)->Level+e.EActor->Mod(A_INT));
                     if ((p->Spells[i] & (SP_DIVINE|SP_INNATE))) 
-                        savedc = max(savedc,10+TEFF(e.eID)->Level+e.EActor->Mod(A_WIS));
+                        savedc = std::max(savedc,10+TEFF(e.eID)->Level+e.EActor->Mod(A_WIS));
                     if ((p->Spells[i] & (SP_PRIMAL|SP_INNATE))) 
-                        savedc = max(savedc,10+TEFF(e.eID)->Level+e.EActor->Mod(A_WIS));
+                        savedc = std::max(savedc,10+TEFF(e.eID)->Level+e.EActor->Mod(A_WIS));
                     if ((p->Spells[i] & (SP_SORCERY|SP_INNATE))) 
-                        savedc = max(savedc,10+TEFF(e.eID)->Level+e.EActor->Mod(A_CHA));
+                        savedc = std::max(savedc,10+TEFF(e.eID)->Level+e.EActor->Mod(A_CHA));
 
 
                     int save_color = (e.saveDC > savedc ? -GREEN :
@@ -213,7 +213,7 @@ ProcessSpells:
                         save_string = "       ";
                     } else {
                         save_string = Format("%4s %2d",
-                            SaveNames[min(3,TEFF(theGame->SpellID(i))->ef.sval % 10)],
+                            SaveNames[std::min(3,TEFF(theGame->SpellID(i))->ef.sval % 10)],
                             e.saveDC);
                     } 
 
@@ -426,7 +426,7 @@ DoneAB:
                 p->QuickKeys[sp-'0'].Type = QKY_SPELL;
                 goto ProcessSpells;
             }
-            if (sp >= 'a' && sp <= min<int>('z',ch-1)) {
+            if (sp >= 'a' && sp <= std::min<int>('z',ch-1)) {
                 Restore();
                 SetMode(oldMode);
                 return Spells[sp - 'a'];
@@ -913,9 +913,9 @@ ResetCurrCon:
                 int16 o_off = offset;
                 SetWin(WIN_INVEN);
                 if (offset > yContents[CurrSlot - NUM_SLOTS])
-                    offset = max(0, yContents[CurrSlot - NUM_SLOTS] - 4);
+                    offset = std::max(0, yContents[CurrSlot - NUM_SLOTS] - 4);
                 else if (offset + (WinSizeY() - (NUM_SLOTS)) < yContents[CurrSlot - NUM_SLOTS] + 4)
-                    offset = max(0, (yContents[CurrSlot - NUM_SLOTS] + 4) - (WinSizeY() - (NUM_SLOTS)));
+                    offset = std::max(0, (yContents[CurrSlot - NUM_SLOTS] + 4) - (WinSizeY() - (NUM_SLOTS)));
                 if (offset != o_off)
                     UpdateScrollArea(offset);
             }
@@ -934,9 +934,9 @@ ResetCurrCon:
                 int16 o_off = offset;
                 SetWin(WIN_INVEN);
                 if (offset > yContents[CurrSlot - NUM_SLOTS])
-                    offset = max(0, yContents[CurrSlot - NUM_SLOTS] - 4);
+                    offset = std::max(0, yContents[CurrSlot - NUM_SLOTS] - 4);
                 else if (offset + (WinSizeY() - (NUM_SLOTS)) < yContents[CurrSlot - NUM_SLOTS])
-                    offset = max(0, (yContents[CurrSlot - NUM_SLOTS] + 4) - (WinSizeY() - (NUM_SLOTS)));
+                    offset = std::max(0, (yContents[CurrSlot - NUM_SLOTS] + 4) - (WinSizeY() - (NUM_SLOTS)));
                 if (offset != o_off)
                     UpdateScrollArea(offset);
             } else if (currCon && conCursor && CurrSlot == SL_PACK)
@@ -1018,9 +1018,9 @@ default_label:
                             int16 o_off = offset;
                             SetWin(WIN_INVEN);
                             if (offset > yContents[CurrSlot - NUM_SLOTS])
-                                offset = max(0, yContents[CurrSlot - NUM_SLOTS] - 4);
+                                offset = std::max(0, yContents[CurrSlot - NUM_SLOTS] - 4);
                             else if (offset + (WinSizeY() - (NUM_SLOTS)) < yContents[CurrSlot - NUM_SLOTS])
-                                offset = max(0, (yContents[CurrSlot - NUM_SLOTS] + 4) - (WinSizeY() - (NUM_SLOTS)));
+                                offset = std::max(0, (yContents[CurrSlot - NUM_SLOTS] + 4) - (WinSizeY() - (NUM_SLOTS)));
                             if (offset != o_off)
                                 UpdateScrollArea(offset);
                         }
@@ -1447,7 +1447,7 @@ SellItem:
         return;
     }
 
-    if (!yn(XPrint("<Obj> offers <Num> gp for that. Accept?", Seller, min(Seller->getTotalMoney(), it->getShopCost(Seller, p))))) {
+    if (!yn(XPrint("<Obj> offers <Num> gp for that. Accept?", Seller, std::min(Seller->getTotalMoney(), it->getShopCost(Seller, p))))) {
         p->GainItem(it, false);
         SetWin(WIN_INVEN);
         Clear();
@@ -1457,7 +1457,7 @@ SellItem:
 
     it->Remove(false);
     Seller->GainItem(it, false);
-    Seller->LoseMoneyTo(min(Seller->getTotalMoney(),
+    Seller->LoseMoneyTo(std::min(Seller->getTotalMoney(),
         it->getShopCost(Seller, p)), p);
     p->IPrint("You sell the <Obj> a <Obj>.", Seller, it);
     SetWin(WIN_INVEN);
@@ -1692,7 +1692,7 @@ Recount:
                 PutChar(0, sl + ln, '>');
                 break;
             case KY_CMD_SOUTH:
-                if (ln >= min<int>(j, SKILLS_SHOWN)) {
+                if (ln >= std::min<int>(j, SKILLS_SHOWN)) {
                     if (offset + SKILLS_SHOWN < (SK_LAST - 1)) {
                         offset++;
                         goto ReDraw;
@@ -1875,7 +1875,7 @@ void TextTerm::OptionManager(int16 start_cat) {
 
         Color(GREY);
         if (Sec == OPC_MACROS) {
-            for (i = Off; i < min(Off + (WinSizeY() - 13), MAX_MACROS); i++) {
+            for (i = Off; i < std::min(Off + (WinSizeY() - 13), MAX_MACROS); i++) {
                 Color(pp->Macros[i] ? EMERALD : GREY);
                 Write(4, 3 + (i - Off), Format(i <= 12 ? "F%d" :
                     i <= 24 ? "CTRL+F%d" :
@@ -1887,7 +1887,7 @@ void TextTerm::OptionManager(int16 start_cat) {
             }
         } else if (!n)
             Write(4, 4, "[No Options Yet]");
-        else for (i = Off; i < min<int>(Off + (WinSizeY() - 13), n); i++) {
+        else for (i = Off; i < std::min<int>(Off + (WinSizeY() - 13), n); i++) {
             Color(i == c ? EMERALD : GREY);
             Write(4, 4 + (i - Off), OptionList[OptsShown[i]].Name);
             Color(YELLOW);
@@ -2093,7 +2093,7 @@ void TextTerm::DisplayCharSheet() {
         for (i = 0; i < 7; i++) {
             y2 += SWrapWrite(24, y2, cs.sAttr[i], 79, WIN_CSHEET);
         }
-        y = max(y1, y2) + 1;
+        y = std::max(y1, y2) + 1;
 
         for (i = 0; i < 3; i++)
             y += SWrapWrite(1, y, cs.sSaves[i], 79, WIN_CSHEET);

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -1503,7 +1503,7 @@ String & Feature::Name(int16 Flags) {
     s = NAME(fID);
 
     if (cHP > 0 && (Flags & NA_LONG))
-        switch ((cHP * 10) / max(1, mHP))
+        switch ((cHP * 10) / max<int>(1, mHP))
     {
         case 10: break;
         case 9:

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -988,7 +988,7 @@ String & Creature::Name(int16 Flags) {
         else
             s = SC("male ") + s;
 
-        switch ((cHP * 10) / max(1, (mHP + Attr[A_THP]))) {
+        switch ((cHP * 10) / std::max(1, (mHP + Attr[A_THP]))) {
         case 10: s = SC("uninjured ") + s; break;
         case 9:
         case 8:  s = SC("mildly injured ") + s; break;
@@ -1240,7 +1240,7 @@ String & Item::Name(int16 Flags) {
         ofWords[i].Empty();
 
     if (!(eID && TEFF(eID)->HasFlag(EF_HIDEQUAL)))
-        for (i = 1; i < max(WQ_TRUELAST, AQ_TRUELAST); i++)
+        for (i = 1; i < std::max(WQ_TRUELAST, AQ_TRUELAST); i++)
             if (KnownQuality(i) || (HasQuality(i) && Flags & NA_IDENT)) {
                 if (LookupOnly(GenericPreQualNames, i)) {
                     xe.nPrequal += Lookup(GenericPreQualNames, i); xe.nPrequal += " ";
@@ -1503,7 +1503,7 @@ String & Feature::Name(int16 Flags) {
     s = NAME(fID);
 
     if (cHP > 0 && (Flags & NA_LONG))
-        switch ((cHP * 10) / max<int>(1, mHP))
+        switch ((cHP * 10) / std::max<int>(1, mHP))
     {
         case 10: break;
         case 9:

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -311,7 +311,7 @@ void Monster::ChooseAction()
   
   if (!m || (x==-1))
     {
-      Timeout = max(Timeout,30);
+      Timeout = max<int>(Timeout,30);
       return;
     }
 
@@ -352,7 +352,7 @@ void Monster::ChooseAction()
 
   if (!m || (x==-1))
   {
-    Timeout = max(Timeout,30);
+    Timeout = max<int>(Timeout,30);
     return;
   }
 
@@ -1700,7 +1700,7 @@ RetryTargets:
         he instead becomes a strongly /negative/ gravity, repulsing the
         monster until it's back at a safe distance for it's favoured
         tactic of ranged combat. */
-        d = max(1, ts.t[i].DistanceFrom(this));
+        d = max<int>(1, ts.t[i].DistanceFrom(this));
         if (ts.t[i].type == TargetWander)
             d = 1;
         else if ((ts.t[i].type == TargetEnemy ||
@@ -2770,7 +2770,7 @@ int16 Monster::RateAsTarget(Thing *t)
          Magical Aura on them, but not others. */
       Shiny:
       lev = ((Item*)t)->PItemLevel(this) + 1;
-      rat = (10 * min(lev,max(25,t->GetStatiMag(MAGIC_AURA)))) / max(1,ChallengeRating()/3);
+      rat = (10 * min<int>(lev,max<int>(25,t->GetStatiMag(MAGIC_AURA)))) / max(1,ChallengeRating()/3);
       if (rat <= 0)
         return  0;
 
@@ -2781,7 +2781,7 @@ int16 Monster::RateAsTarget(Thing *t)
       else if (HasMFlag(M_COVETOUS))
         rat *= 2;
       
-      rat = min(126,rat);
+      rat = min<int>(126,rat);
       
       ASSERT(rat >= 0 && rat <= 127) 
       return rat;

--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -311,7 +311,7 @@ void Monster::ChooseAction()
   
   if (!m || (x==-1))
     {
-      Timeout = max<int>(Timeout,30);
+      Timeout = std::max<int>(Timeout,30);
       return;
     }
 
@@ -352,13 +352,13 @@ void Monster::ChooseAction()
 
   if (!m || (x==-1))
   {
-    Timeout = max<int>(Timeout,30);
+    Timeout = std::max<int>(Timeout,30);
     return;
   }
 
   charmer = (Creature*)GetStatiObj(CHARMED,CH_CHARM);
 
-#define sdist(vx,vy,tx,ty) max(MYABS(vx - tx),MYABS(vy - ty))
+#define sdist(vx,vy,tx,ty) std::max(MYABS(vx - tx),MYABS(vy - ty))
 
   if (ts.shouldRetarget) ts.Retarget(this,true);
 
@@ -731,7 +731,7 @@ SkipShifting:
                   best = j;
                 }
       if (bc)
-        AddAct(ACT_CAST,max(0,(best / 256) - HasMFlag(M_EVIL))-1,bc,
+        AddAct(ACT_CAST, std::max(0,(best / 256) - HasMFlag(M_EVIL))-1,bc,
             EP_FIX_TROUBLE + ((best & 0xFF)<<16));
     }
     /* Later, add support for buffing allies as well. */
@@ -1700,7 +1700,7 @@ RetryTargets:
         he instead becomes a strongly /negative/ gravity, repulsing the
         monster until it's back at a safe distance for it's favoured
         tactic of ranged combat. */
-        d = max<int>(1, ts.t[i].DistanceFrom(this));
+        d = std::max<int>(1, ts.t[i].DistanceFrom(this));
         if (ts.t[i].type == TargetWander)
             d = 1;
         else if ((ts.t[i].type == TargetEnemy ||
@@ -2301,7 +2301,7 @@ void Monster::AddEffect(TEffect *te, rID eID, Item *src) {
         if (te->ManaCost > cMana())
           return;
 
-        i = (int16)((te->ManaCost*100) / max(1,cMana()));
+        i = (int16)((te->ManaCost*100) / std::max(1,cMana()));
         rat -= (i*rat)/100;    
       }
     
@@ -2382,7 +2382,7 @@ uint32 Monster::SetMetamagic(rID eID, Thing *tar, uint16 Pur)
     uint32 MM; TEffect *te = TEFF(eID);
     // ww: Fri Jan 16 20:19:03 PST 2004
     // I got a division by 0 on the next line. 
-    int16 pMana = (int16)((cMana()*100) / max(tMana(),1));
+    int16 pMana = (int16)((cMana()*100) / std::max(tMana(),1));
 
     /* Right now, this can lead to monsters with lots of different
        MM feats using many at once, wasting mana and casting spells
@@ -2770,7 +2770,7 @@ int16 Monster::RateAsTarget(Thing *t)
          Magical Aura on them, but not others. */
       Shiny:
       lev = ((Item*)t)->PItemLevel(this) + 1;
-      rat = (10 * min<int>(lev,max<int>(25,t->GetStatiMag(MAGIC_AURA)))) / max(1,ChallengeRating()/3);
+      rat = (10 * std::min<int>(lev, std::max<int>(25,t->GetStatiMag(MAGIC_AURA)))) / std::max(1,ChallengeRating()/3);
       if (rat <= 0)
         return  0;
 
@@ -2781,7 +2781,7 @@ int16 Monster::RateAsTarget(Thing *t)
       else if (HasMFlag(M_COVETOUS))
         rat *= 2;
       
-      rat = min<int>(126,rat);
+      rat = std::min<int>(126,rat);
       
       ASSERT(rat >= 0 && rat <= 127) 
       return rat;
@@ -2909,7 +2909,7 @@ int16 Monster::RateAsTarget(Thing *t)
 
       rat += 5;
       // ww: favour close things
-      rat += max(min(30 - dist(x,y,t->x,t->y),30),0);
+      rat += std::max(std::min(30 - dist(x,y,t->x,t->y),30),0);
       ASSERT(rat >= 0 && rat <= 127)
       return rat;
       }
@@ -2920,12 +2920,12 @@ int16 Monster::RateAsTarget(Thing *t)
 int8 Creature::BestHDType()
 {
   TMonster * tm = TMON(mID);
-  int8 b = max(max(MonHDType((int8)tm->MType[0]), MonHDType((int8)tm->MType[1])),
+  int8 b = std::max(std::max(MonHDType((int8)tm->MType[0]), MonHDType((int8)tm->MType[1])),
               MonHDType((int8)tm->MType[2]));
   // ww: now check all templates! 
   StatiIterNature(this,TEMPLATE)
       int8 newType = (int8)TTEM(S->eID)->AddMType;
-      if (newType) b = max(b, MonHDType(newType));
+      if (newType) b = std::max(b, MonHDType(newType));
   StatiIterEnd(this)
   return (b % 100); 
 } 
@@ -2945,7 +2945,7 @@ int16* Creature::getTroubles()
     if (CurrAI != this)
       return Creature::WorstTrouble();
     int16 i, inj = ((mHP+Attr[A_THP]-cHP)*100)/(mHP+Attr[A_THP]),
-         man = (cMana()*100L)/max(nhMana(),1);
+         man = (cMana()*100L) / std::max(nhMana(),1);
     
     if (isStoning)
       Troubles[n++] = TROUBLE_STONING + P_CRITICAL*256;

--- a/src/Move.cpp
+++ b/src/Move.cpp
@@ -92,8 +92,8 @@ EvReturn Creature::Walk(EventInfo &e) {
 			}
 			if (isPlayer())
 				if (!yn(Format("You have a %d~ chance of convincing your mount and a %d~ chance of making the jump. Jump?",
-					100 - max(0, (DC - SkillLevel(SK_RIDE)) * 5),
-					100 - max(0, (DC - mount->SkillLevel(SK_JUMP)) * 5)
+					100 - std::max(0, (DC - SkillLevel(SK_RIDE)) * 5),
+					100 - std::max(0, (DC - mount->SkillLevel(SK_JUMP)) * 5)
 				)))
 					return ABORT;
 
@@ -111,7 +111,7 @@ EvReturn Creature::Walk(EventInfo &e) {
 			}
 			if (isPlayer())
 				if (!yn(Format("You have a %d~ chance of success. Jump?",
-					100 - max(0, (DC - SkillLevel(SK_JUMP)) * 5))))
+					100 - std::max(0, (DC - SkillLevel(SK_JUMP)) * 5))))
 					return ABORT;
 			jcheck = (SkillCheck(SK_JUMP, DC));
 		}
@@ -324,7 +324,7 @@ EvReturn Creature::Walk(EventInfo &e) {
 						dis = cr;
 						goto IgnoreCreature;
 					}
-					else if (ChallengeRating() >= min(6, cr->ChallengeRating() + 5))
+					else if (ChallengeRating() >= std::min(6, cr->ChallengeRating() + 5))
 						if (isMonster() && cr->isMonster())
 							if (GetAttr(A_STR) >= cr->GetAttr(A_STR) + 4)
 								if (cr->GetAttr(A_MOV)) {
@@ -814,7 +814,7 @@ SkipConfirms:
 	that the player understand when they are entering or leaving
 	a monster's threatened area, and vice versa. Hence, we use this
 	macro instead of dist(). */
-#define sdist(vx,vy,t) max(MYABS(vx - t->x),MYABS(vy - t->y))
+#define sdist(vx,vy,t) std::max(MYABS(vx - t->x),MYABS(vy - t->y))
 
 	bool failed = false;
 	int8 myHit, crHit; ch = 0;
@@ -861,13 +861,13 @@ SkipConfirms:
 						}
 					}
 					else {
-						myHit = max((int8)Attr[A_HIT_BRAWL], (int8)Attr[A_HIT_MELEE]);
+						myHit = std::max((int8)Attr[A_HIT_BRAWL], (int8)Attr[A_HIT_MELEE]);
 						if (HasFeat(FT_TACTICAL_WITHDRAWL))
 							myHit += 8;
-						crHit = max((int8)cr->Attr[A_HIT_BRAWL], (int8)cr->Attr[A_HIT_MELEE]);
+						crHit = std::max((int8)cr->Attr[A_HIT_BRAWL], (int8)cr->Attr[A_HIT_MELEE]);
 						if (myHit + (random(20) + 1) >= crHit + 11)
 							/* Give the player a hope of actually escaping. */
-							cr->Timeout = max<int>(cr->Timeout, 15);
+							cr->Timeout = std::max<int>(cr->Timeout, 15);
 						else {
 							if (!failed)
 								DPrint(e, "You fail to break off melee safely.",
@@ -1094,7 +1094,7 @@ SkipConfirms:
 	case EV_MOVE:
 	{
 		int32 needed_timeout = MoveTimeout(ox, oy);
-		needed_timeout = min(needed_timeout, max(12, needed_timeout - StoredMovementTimeout));
+		needed_timeout = std::min(needed_timeout, std::max(12, needed_timeout - StoredMovementTimeout));
 		Timeout += (int16)needed_timeout;
 		StoredMovementTimeout = 0;
 	}

--- a/src/Move.cpp
+++ b/src/Move.cpp
@@ -867,7 +867,7 @@ SkipConfirms:
 						crHit = max((int8)cr->Attr[A_HIT_BRAWL], (int8)cr->Attr[A_HIT_MELEE]);
 						if (myHit + (random(20) + 1) >= crHit + 11)
 							/* Give the player a hope of actually escaping. */
-							cr->Timeout = max(cr->Timeout, 15);
+							cr->Timeout = max<int>(cr->Timeout, 15);
 						else {
 							if (!failed)
 								DPrint(e, "You fail to break off melee safely.",

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1640,7 +1640,7 @@ void Player::IntuitItem(Item *it) {
         it->Inscrip = levels[0];
     else
         it->Inscrip = levels[1 +
-        min(min(it->PItemLevel(this) / 3, (precision / 4)), 6)];
+        std::min(std::min(it->PItemLevel(this) / 3, (precision / 4)), 6)];
     // itemlevel ranges from around 0 to 25
 
     it->Inscrip = XPrint(it->Inscrip);
@@ -1827,7 +1827,7 @@ EvReturn Player::SpendHours(int16 minHours, int16 maxHours, int16 &hoursSpent, b
         return ABORT;
     }
 
-    hoursSpent = min(maxHours, (int16)((AllowedTime - AwakeTime) / HOUR_TURNS));
+    hoursSpent = std::min(maxHours, (int16)((AllowedTime - AwakeTime) / HOUR_TURNS));
 
     theGame->Turn += hoursSpent * HOUR_TURNS;
     if (hoursSpent == 1)
@@ -1944,7 +1944,7 @@ EvReturn Player::Rest(EventInfo &e) {
                 IPrint(msg);
             }
             oChance = Chance;
-            Chance = max(0, Chance - sumSpot);
+            Chance = std::max(0, Chance - sumSpot);
             if (Roll < oChance && !(e.EParam & REST_SAFE))
                 if (Roll >= Chance)
                     IPrint("Your feel you are evaluated, but your " \
@@ -1966,7 +1966,7 @@ EvReturn Player::Rest(EventInfo &e) {
 
         ASSERT(dID);
 
-        int32 maxDepthHere = min<int>(MAX_DUNGEON_LEVELS,
+        int32 maxDepthHere = std::min<int>(MAX_DUNGEON_LEVELS,
             TDUN(dID)->GetConst(DUN_DEPTH) + 1);
         int32 depth;
 
@@ -2040,7 +2040,7 @@ EvReturn Player::Rest(EventInfo &e) {
                                 a_hp = A_WIS;
 
                             if (!(t->isMType(MA_UNDEAD) || t->isMType(MA_CONSTRUCT))) {
-                                t->cHP = min(t->mHP + t->Attr[A_THP], t->cHP +
+                                t->cHP = std::min(t->mHP + t->Attr[A_THP], t->cHP +
                                     ((t->ChallengeRating() + 3) * t->Attr[a_hp] * Percent) /
                                     800);
                                 if (t->cHP < t->mHP + t->Attr[A_THP] && t->HasSkill(SK_HEAL, true)) {
@@ -2050,7 +2050,7 @@ EvReturn Player::Rest(EventInfo &e) {
                                         t->IPrint("You tend your wounds with your skill as a healer.");
                                     else
                                         t->IPrint("The <Obj1> tends your wounds with <his:Obj1> skill as a healer.", healer);
-                                    t->cHP = min(t->mHP + t->Attr[A_THP], t->cHP +
+                                    t->cHP = std::min(t->mHP + t->Attr[A_THP], t->cHP +
                                         ((healer->SkillLevel(SK_HEAL)) * t->Attr[a_hp] * Percent) /
                                         500);
                                 }
@@ -2102,17 +2102,17 @@ EvReturn Player::Rest(EventInfo &e) {
                                 // point back per rest, and resting 10 times is *way*
                                 // boring. New theory: a full night's sleep always gets
                                 // you back to at least 1 point of fatigue. 
-                                t->cFP = (min<int>(t->Attr[A_FAT], t->cFP + max<int>(1, t->Mod((int8)a_hp))));
+                                t->cFP = (std::min<int>(t->Attr[A_FAT], t->cFP + std::max<int>(1, t->Mod((int8)a_hp))));
                         } else {                          /* Exhausted */
                             if (Percent == 100)
-                                t->cFP = max(min<int>(t->Attr[A_FAT], t->cFP + max<int>(1, t->Mod((int8)a_hp))), 1);
+                                t->cFP = std::max(std::min<int>(t->Attr[A_FAT], t->cFP + std::max<int>(1, t->Mod((int8)a_hp))), 1);
                             else
                                 t->cFP += 1;
                         }
                         if (t->InSlot(SL_ARMOUR) && t->InSlot(SL_ARMOUR)->isCursed())
                         {
                             t->IPrint("Resting in your cursed armour prevents decent sleep.");
-                            t->cFP = min<int>(t->cFP, -1);
+                            t->cFP = std::min<int>(t->cFP, -1);
                         }
 
                         // ww: just before you wake up they all cast Stoneskin ...
@@ -2413,7 +2413,7 @@ RestartTerra:
                             the player can't "scum" a level for items through
                             repetition. */
                             for (it = cr->FirstInv(); it; it = cr->NextInv())
-                                if (it->isMagic() && it->ItemLevel() > min(Depth / 2, Depth - 4)) {
+                                if (it->isMagic() && it->ItemLevel() > std::min(Depth / 2, Depth - 4)) {
                                     if (it->isType(T_WEAPON) || it->isType(T_ARMOUR) ||
                                         it->isType(T_SHIELD) || it->isType(T_MISSILE) ||
                                         it->isType(T_CONTAIN))
@@ -2836,13 +2836,13 @@ void Character::Exercise(int16 at, int16 amt, int16 col, int16 cap) {
     case A_STR:
     case A_DEX:
     case A_CON:
-        needed = 100 - max<int>(0, SkillLevel(SK_ATHLETICS));
+        needed = 100 - std::max<int>(0, SkillLevel(SK_ATHLETICS));
         break;
     case A_WIS:
-        needed = 100 - max<int>(0, SkillLevel(SK_CONCENT));
+        needed = 100 - std::max<int>(0, SkillLevel(SK_CONCENT));
         break;
     case A_CHA:
-        needed = 100 - max<int>(0, SkillLevel(SK_PERFORM));
+        needed = 100 - std::max<int>(0, SkillLevel(SK_PERFORM));
         break;
     case A_INT:
         sk = 0;
@@ -2860,7 +2860,7 @@ void Character::Exercise(int16 at, int16 amt, int16 col, int16 cap) {
     for (i = 0; i != 15; i++)
         total += GainAttr[at][i];
 
-    adding = min<int>(cap - GainAttr[at][col], amt);
+    adding = std::min<int>(cap - GainAttr[at][col], amt);
 
     if (total + adding > needed) {
         adding = amt - (needed - total);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1966,7 +1966,7 @@ EvReturn Player::Rest(EventInfo &e) {
 
         ASSERT(dID);
 
-        int32 maxDepthHere = min(MAX_DUNGEON_LEVELS,
+        int32 maxDepthHere = min<int>(MAX_DUNGEON_LEVELS,
             TDUN(dID)->GetConst(DUN_DEPTH) + 1);
         int32 depth;
 
@@ -2102,17 +2102,17 @@ EvReturn Player::Rest(EventInfo &e) {
                                 // point back per rest, and resting 10 times is *way*
                                 // boring. New theory: a full night's sleep always gets
                                 // you back to at least 1 point of fatigue. 
-                                t->cFP = (min(t->Attr[A_FAT], t->cFP + max(1, t->Mod((int8)a_hp))));
+                                t->cFP = (min<int>(t->Attr[A_FAT], t->cFP + max<int>(1, t->Mod((int8)a_hp))));
                         } else {                          /* Exhausted */
                             if (Percent == 100)
-                                t->cFP = max(min(t->Attr[A_FAT], t->cFP + max(1, t->Mod((int8)a_hp))), 1);
+                                t->cFP = max(min<int>(t->Attr[A_FAT], t->cFP + max<int>(1, t->Mod((int8)a_hp))), 1);
                             else
                                 t->cFP += 1;
                         }
                         if (t->InSlot(SL_ARMOUR) && t->InSlot(SL_ARMOUR)->isCursed())
                         {
                             t->IPrint("Resting in your cursed armour prevents decent sleep.");
-                            t->cFP = min(t->cFP, -1);
+                            t->cFP = min<int>(t->cFP, -1);
                         }
 
                         // ww: just before you wake up they all cast Stoneskin ...
@@ -2836,13 +2836,13 @@ void Character::Exercise(int16 at, int16 amt, int16 col, int16 cap) {
     case A_STR:
     case A_DEX:
     case A_CON:
-        needed = 100 - max(0, SkillLevel(SK_ATHLETICS));
+        needed = 100 - max<int>(0, SkillLevel(SK_ATHLETICS));
         break;
     case A_WIS:
-        needed = 100 - max(0, SkillLevel(SK_CONCENT));
+        needed = 100 - max<int>(0, SkillLevel(SK_CONCENT));
         break;
     case A_CHA:
-        needed = 100 - max(0, SkillLevel(SK_PERFORM));
+        needed = 100 - max<int>(0, SkillLevel(SK_PERFORM));
         break;
     case A_INT:
         sk = 0;
@@ -2860,7 +2860,7 @@ void Character::Exercise(int16 at, int16 amt, int16 col, int16 cap) {
     for (i = 0; i != 15; i++)
         total += GainAttr[at][i];
 
-    adding = min(cap - GainAttr[at][col], amt);
+    adding = min<int>(cap - GainAttr[at][col], amt);
 
     if (total + adding > needed) {
         adding = amt - (needed - total);

--- a/src/Prayer.cpp
+++ b/src/Prayer.cpp
@@ -431,7 +431,7 @@ EvReturn Character::Sacrifice(EventInfo &e)
     if (e.EVictim) {
       if (sacVal > SacVals[e.godNum][sacCat])
         isImpressed = true;
-      newVal = max(SacVals[e.godNum][sacCat],sacVal);
+      newVal = std::max(SacVals[e.godNum][sacCat],sacVal);
       }
     else {
       newVal = SacVals[e.godNum][sacCat] + (sacVal / 3);
@@ -460,7 +460,7 @@ EvReturn Character::Sacrifice(EventInfo &e)
             return DONE;
           }
         */
-        Anger[e.godNum] = max(0,Anger[e.godNum]-3);
+        Anger[e.godNum] = std::max(0,Anger[e.godNum]-3);
         if (Anger[e.godNum] > 0)
           GodMessage(e.eID,MSG_LESSENED);
         else
@@ -469,7 +469,7 @@ EvReturn Character::Sacrifice(EventInfo &e)
       }
     
     SacVals[e.godNum][sacCat] = 
-      max(newVal,SacVals[e.godNum][sacCat]);
+        std::max(newVal,SacVals[e.godNum][sacCat]);
     
     if (isImpressed) {
       GodMessage(e.eID,MSG_IMPRESSED);
@@ -517,7 +517,7 @@ void Character::lowerAnger(rID gID, int16 amt)
       return;
     if (Anger[gn] && amt)
       {
-        Anger[gn] = max(0,Anger[gn] - amt);
+        Anger[gn] = std::max(0,Anger[gn] - amt);
         if (Anger[gn] > 0)
           GodMessage(gID,MSG_LESSENED);
         else
@@ -568,7 +568,7 @@ EvReturn Character::Jealousy(EventInfo &e)
       return DONE;
         
         
-    if (doWrath || EventStack[max(0,EventSP-1)].Event == EV_CONVERT)
+    if (doWrath || EventStack[std::max(0,EventSP-1)].Event == EV_CONVERT)
       Transgress(GodID,mag,true,"divine jealousy");
     else
       Transgress(GodID,mag,false,"divine jealousy");
@@ -581,7 +581,7 @@ void Character::gainFavour(rID gID, int32 amt, bool advance, bool stack)
     if (stack)
       SacVals[theGame->GodNum(gID)][MAX_SAC_CATS+1] += amt;
     else
-      SacVals[theGame->GodNum(gID)][MAX_SAC_CATS] = max(amt,
+      SacVals[theGame->GodNum(gID)][MAX_SAC_CATS] = std::max(amt,
         SacVals[theGame->GodNum(gID)][MAX_SAC_CATS]);
     
     if (advance && gID == GodID)
@@ -672,12 +672,12 @@ int16* Creature::getTroubles()
       }
       
     int32 inj = (((mHP+Attr[A_THP])-cHP)*100)/(mHP+Attr[A_THP]),
-         man = (cMana()*100L)/max(nhMana(),1);
+         man = (cMana()*100L) / std::max(nhMana(),1);
     
     /* Mana is CRITICAL to mages, priests & druids, somewhat critical
        to fighter-mages and less significant to everyone else, so
        adjust accordingly. */   
-    man = ((man * 30L) + ((man * 70L * CasterLev()) / max<int>(1,ChallengeRating()))) / 100;
+    man = ((man * 30L) + ((man * 70L * CasterLev()) / std::max<int>(1,ChallengeRating()))) / 100;
     
     n = 0;
     
@@ -1169,7 +1169,7 @@ EvReturn Character::Convert(EventInfo &e)
     
     neededFavour = (int16)TGOD(e.eID)->GetConst(MIN_CONVERT_FAVOUR);    
     if (getGodFlags(e.eID) & GS_FORSAKEN)
-      neededFavour = max(neededFavour*5,5000);
+      neededFavour = std::max(neededFavour*5,5000);
     
     if (!GodID)
       neededFavour /= 10;
@@ -1210,7 +1210,7 @@ EvReturn Character::Convert(EventInfo &e)
          array, but this may change in the future when I come up with
          a method that's both in-game logical and OOC balanced.
          */
-      FavPenalty[e.godNum] = max(FavPenalty[e.godNum],
+      FavPenalty[e.godNum] = std::max(FavPenalty[e.godNum],
              FavPenalty[theGame->GodNum(GodID)]);
 
       }
@@ -1353,7 +1353,7 @@ EvReturn Character::GodDeflect(EventInfo &e)
     if (FavPenalty[e.godNum] + TGOD(GodID)->GetConst(INTERVENTION_COST) > 100)
       return NOTHING;
       
-    if (Anger[e.godNum] > max<int>(3,(int16)TGOD(GodID)->GetConst(TOLERANCE_VAL)))
+    if (Anger[e.godNum] > std::max<int>(3,(int16)TGOD(GodID)->GetConst(TOLERANCE_VAL)))
       return NOTHING;
       
     if (getGodFlags(GodID) & (GS_ANATHEMA|GS_FORSAKEN))
@@ -1400,7 +1400,7 @@ EvReturn Player::GodRaise(EventInfo &e)
     if (FavPenalty[e.godNum] + TGOD(e.eID)->GetConst(RESURRECTION_COST) > 100)
       return NOTHING;
       
-    if (Anger[e.godNum] > max<int>(3,(int16)TGOD(e.eID)->GetConst(TOLERANCE_VAL)))
+    if (Anger[e.godNum] > std::max<int>(3,(int16)TGOD(e.eID)->GetConst(TOLERANCE_VAL)))
       return NOTHING;
       
     if (getGodFlags(e.eID) & (GS_ANATHEMA|GS_FORSAKEN))
@@ -1441,14 +1441,14 @@ EvReturn Player::GodRaise(EventInfo &e)
         return DONE;
       }
          
-    resChance -= max(0,(10 - Mod(A_CON)));
+    resChance -= std::max(0,(10 - Mod(A_CON)));
     
     /* Intervention Penalty */
     FavPenalty[e.godNum] += (int16)TGOD(GodID)->GetConst(RESURRECTION_COST);
     
     /* You have enough XP for the level right below the one you are
        currently at -- simulate losing a level. */
-    XP = max(0,min<int>(XP-2000,(XP*85L)/100L));
+    XP = std::max(0, std::min<int>(XP-2000,(XP*85L)/100L));
     
     /* Reduce Con by one permanently */
     BAttr[A_CON]--;
@@ -1648,7 +1648,7 @@ void Character::Forsake()
         if (Anger[theGame->GodNum(GodID)] > 30)
           goto realForsake;
         GodMessage(GodID,MSG_PENANCE);
-        Anger[theGame->GodNum(GodID)] = max<int>(10 +
+        Anger[theGame->GodNum(GodID)] = std::max<int>(10 +
           (int16)TGOD(GodID)->GetConst(TOLERANCE_VAL),
           Anger[theGame->GodNum(GodID)]);
         
@@ -1658,7 +1658,7 @@ void Character::Forsake()
       
     realForsake:
     GodMessage(GodID,MSG_FORSAKE);
-    Anger[theGame->GodNum(GodID)] = max<int>(10 +
+    Anger[theGame->GodNum(GodID)] = std::max<int>(10 +
       (int16)TGOD(GodID)->GetConst(TOLERANCE_VAL),
       Anger[theGame->GodNum(GodID)]);
     setGodFlags(GodID, GS_FORSAKEN);    
@@ -2032,7 +2032,7 @@ EvReturn Character::AlignedAct(EventInfo &e)
       else if (e.EParam & AL_GOOD)
         alignGE -= (int16)e.vMag;
       if (!(dAlign & AL_GOOD))
-        alignGE = max<int>(-30, alignGE);
+        alignGE = std::max<int>(-30, alignGE);
       }
     else if (cAlign & AL_EVIL) {
       if (e.EParam & AL_NONEVIL) {
@@ -2042,12 +2042,12 @@ EvReturn Character::AlignedAct(EventInfo &e)
       else if (e.EParam & AL_EVIL)
         alignGE += (int16)e.vMag;
       if (!(dAlign & AL_EVIL))
-        alignGE = min<int>(30, alignGE);
+        alignGE = std::min<int>(30, alignGE);
       }
     else if (e.EParam & AL_GOOD) {
       alignGE -= (int16)e.vMag;
       if (!(dAlign & AL_GOOD))
-        alignGE = max<int>(alignGE,0);
+        alignGE = std::max<int>(alignGE,0);
       }
     else if (e.EParam & AL_EVIL)
       alignGE += (int16)e.vMag;
@@ -2073,7 +2073,7 @@ EvReturn Character::AlignedAct(EventInfo &e)
       else if (e.EParam & AL_LAWFUL)
         alignLC -= (int16)e.vMag;
       if (!(dAlign & AL_LAWFUL))
-        alignLC = max<int>(-30, alignLC);
+        alignLC = std::max<int>(-30, alignLC);
       }
     else if (cAlign & AL_CHAOTIC) {
       if (e.EParam & AL_NONCHAOTIC) {
@@ -2086,21 +2086,21 @@ EvReturn Character::AlignedAct(EventInfo &e)
       else if (e.EParam & AL_CHAOTIC)
         alignLC += (int16)e.vMag;
       if (!(dAlign & AL_CHAOTIC))
-        alignLC = max<int>(30, alignLC);
+        alignLC = std::max<int>(30, alignLC);
       }
     else if (e.EParam & AL_LAWFUL) {
       alignLC -= (int16)e.vMag;
       if (!(dAlign & AL_LAWFUL))
-        alignLC = max<int>(alignLC,0);
+        alignLC = std::max<int>(alignLC,0);
       }
     else if (e.EParam & AL_CHAOTIC) {
       alignLC -= (int16)e.vMag;
       if (!(dAlign & AL_CHAOTIC))
-        alignLC = min<int>(alignLC,0);
+        alignLC = std::min<int>(alignLC,0);
       }
     
-    alignLC = max(-70,min<int>(70,alignLC));
-    alignGE = max(-70,min<int>(70,alignGE));
+    alignLC = std::max(-70, std::min<int>(70,alignLC));
+    alignGE = std::max(-70, std::min<int>(70,alignGE));
       
     if (alignLC > -20)
       nAlign &= (~AL_LAWFUL);
@@ -2215,7 +2215,7 @@ void Creature::AlignedAct(uint16 type, int16 mag, const char *reason,Creature *v
         }
           
       Complicity:
-      getLeader()->AlignedAct(type,max(1,mag/2),
+      getLeader()->AlignedAct(type, std::max(1,mag/2),
         Format ("complicity to %s",reason));
       }
     else {

--- a/src/Prayer.cpp
+++ b/src/Prayer.cpp
@@ -677,7 +677,7 @@ int16* Creature::getTroubles()
     /* Mana is CRITICAL to mages, priests & druids, somewhat critical
        to fighter-mages and less significant to everyone else, so
        adjust accordingly. */   
-    man = ((man * 30L) + ((man * 70L * CasterLev()) / max(1,ChallengeRating()))) / 100;
+    man = ((man * 30L) + ((man * 70L * CasterLev()) / max<int>(1,ChallengeRating()))) / 100;
     
     n = 0;
     
@@ -1353,7 +1353,7 @@ EvReturn Character::GodDeflect(EventInfo &e)
     if (FavPenalty[e.godNum] + TGOD(GodID)->GetConst(INTERVENTION_COST) > 100)
       return NOTHING;
       
-    if (Anger[e.godNum] > max(3,(int16)TGOD(GodID)->GetConst(TOLERANCE_VAL)))
+    if (Anger[e.godNum] > max<int>(3,(int16)TGOD(GodID)->GetConst(TOLERANCE_VAL)))
       return NOTHING;
       
     if (getGodFlags(GodID) & (GS_ANATHEMA|GS_FORSAKEN))
@@ -1400,7 +1400,7 @@ EvReturn Player::GodRaise(EventInfo &e)
     if (FavPenalty[e.godNum] + TGOD(e.eID)->GetConst(RESURRECTION_COST) > 100)
       return NOTHING;
       
-    if (Anger[e.godNum] > max(3,(int16)TGOD(e.eID)->GetConst(TOLERANCE_VAL)))
+    if (Anger[e.godNum] > max<int>(3,(int16)TGOD(e.eID)->GetConst(TOLERANCE_VAL)))
       return NOTHING;
       
     if (getGodFlags(e.eID) & (GS_ANATHEMA|GS_FORSAKEN))
@@ -1448,7 +1448,7 @@ EvReturn Player::GodRaise(EventInfo &e)
     
     /* You have enough XP for the level right below the one you are
        currently at -- simulate losing a level. */
-    XP = max(0,min(XP-2000,(XP*85L)/100L));
+    XP = max(0,min<int>(XP-2000,(XP*85L)/100L));
     
     /* Reduce Con by one permanently */
     BAttr[A_CON]--;
@@ -1648,7 +1648,7 @@ void Character::Forsake()
         if (Anger[theGame->GodNum(GodID)] > 30)
           goto realForsake;
         GodMessage(GodID,MSG_PENANCE);
-        Anger[theGame->GodNum(GodID)] = max(10 +
+        Anger[theGame->GodNum(GodID)] = max<int>(10 +
           (int16)TGOD(GodID)->GetConst(TOLERANCE_VAL),
           Anger[theGame->GodNum(GodID)]);
         
@@ -1658,7 +1658,7 @@ void Character::Forsake()
       
     realForsake:
     GodMessage(GodID,MSG_FORSAKE);
-    Anger[theGame->GodNum(GodID)] = max(10 +
+    Anger[theGame->GodNum(GodID)] = max<int>(10 +
       (int16)TGOD(GodID)->GetConst(TOLERANCE_VAL),
       Anger[theGame->GodNum(GodID)]);
     setGodFlags(GodID, GS_FORSAKEN);    
@@ -2032,7 +2032,7 @@ EvReturn Character::AlignedAct(EventInfo &e)
       else if (e.EParam & AL_GOOD)
         alignGE -= (int16)e.vMag;
       if (!(dAlign & AL_GOOD))
-        alignGE = max(-30, alignGE);
+        alignGE = max<int>(-30, alignGE);
       }
     else if (cAlign & AL_EVIL) {
       if (e.EParam & AL_NONEVIL) {
@@ -2042,12 +2042,12 @@ EvReturn Character::AlignedAct(EventInfo &e)
       else if (e.EParam & AL_EVIL)
         alignGE += (int16)e.vMag;
       if (!(dAlign & AL_EVIL))
-        alignGE = min(30, alignGE);
+        alignGE = min<int>(30, alignGE);
       }
     else if (e.EParam & AL_GOOD) {
       alignGE -= (int16)e.vMag;
       if (!(dAlign & AL_GOOD))
-        alignGE = max(alignGE,0);
+        alignGE = max<int>(alignGE,0);
       }
     else if (e.EParam & AL_EVIL)
       alignGE += (int16)e.vMag;
@@ -2073,7 +2073,7 @@ EvReturn Character::AlignedAct(EventInfo &e)
       else if (e.EParam & AL_LAWFUL)
         alignLC -= (int16)e.vMag;
       if (!(dAlign & AL_LAWFUL))
-        alignLC = max(-30, alignLC);
+        alignLC = max<int>(-30, alignLC);
       }
     else if (cAlign & AL_CHAOTIC) {
       if (e.EParam & AL_NONCHAOTIC) {
@@ -2086,21 +2086,21 @@ EvReturn Character::AlignedAct(EventInfo &e)
       else if (e.EParam & AL_CHAOTIC)
         alignLC += (int16)e.vMag;
       if (!(dAlign & AL_CHAOTIC))
-        alignLC = max(30, alignLC);
+        alignLC = max<int>(30, alignLC);
       }
     else if (e.EParam & AL_LAWFUL) {
       alignLC -= (int16)e.vMag;
       if (!(dAlign & AL_LAWFUL))
-        alignLC = max(alignLC,0);
+        alignLC = max<int>(alignLC,0);
       }
     else if (e.EParam & AL_CHAOTIC) {
       alignLC -= (int16)e.vMag;
       if (!(dAlign & AL_CHAOTIC))
-        alignLC = min(alignLC,0);
+        alignLC = min<int>(alignLC,0);
       }
     
-    alignLC = max(-70,min(70,alignLC));
-    alignGE = max(-70,min(70,alignGE));
+    alignLC = max(-70,min<int>(70,alignLC));
+    alignGE = max(-70,min<int>(70,alignGE));
       
     if (alignLC > -20)
       nAlign &= (~AL_LAWFUL);

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -587,7 +587,7 @@ foundGroup:
     CFile *cf = new CFile(&t);
     cf->LoadCompressed(t.Tell(), gh.compSize, gh.groupSize, use_lz);
 
-    LastUsedHandle = max(LastUsedHandle, gh.LastHandle);
+    LastUsedHandle = max<hObj>(LastUsedHandle, gh.LastHandle);
     for (i=0; i != gh.objCount; i++) {
         /* What type of object is this? */
         cf->FRead(&oType,1);                   
@@ -734,7 +734,7 @@ bool Game::SaveGame(Player &p) {
             { p.MyTerm->Message("Save File Backup: Failed (#3)"); goto failed; }
           off_t sofar;
           for (sofar = 0; sofar < statbuf.st_size;) {
-              size_t this_read = fread(buf,1,min(sizeof(buf),statbuf.st_size - sofar),fin);
+              size_t this_read = fread(buf,1,min<int>(sizeof(buf),statbuf.st_size - sofar),fin);
               if (this_read == 0) 
                 { p.MyTerm->Message("Save File Backup: Failed (#4)"); goto failed; }
               size_t this_write ;

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -235,7 +235,7 @@ hObj Registry::RegisterObject(Object *o, bool loaded)
     hObj h; RegNode *r;
     if (loaded) {
       h = o->myHandle;
-      LastUsedHandle = max(LastUsedHandle,h+1);
+      LastUsedHandle = std::max(LastUsedHandle,h+1);
       }
     else
       h = LastUsedHandle++;
@@ -587,7 +587,7 @@ foundGroup:
     CFile *cf = new CFile(&t);
     cf->LoadCompressed(t.Tell(), gh.compSize, gh.groupSize, use_lz);
 
-    LastUsedHandle = max<hObj>(LastUsedHandle, gh.LastHandle);
+    LastUsedHandle = std::max<hObj>(LastUsedHandle, gh.LastHandle);
     for (i=0; i != gh.objCount; i++) {
         /* What type of object is this? */
         cf->FRead(&oType,1);                   
@@ -734,7 +734,7 @@ bool Game::SaveGame(Player &p) {
             { p.MyTerm->Message("Save File Backup: Failed (#3)"); goto failed; }
           off_t sofar;
           for (sofar = 0; sofar < statbuf.st_size;) {
-              size_t this_read = fread(buf,1,min<int>(sizeof(buf),statbuf.st_size - sofar),fin);
+              size_t this_read = fread(buf,1,std::min<int>(sizeof(buf),statbuf.st_size - sofar),fin);
               if (this_read == 0) 
                 { p.MyTerm->Message("Save File Backup: Failed (#4)"); goto failed; }
               size_t this_write ;

--- a/src/Res.cpp
+++ b/src/Res.cpp
@@ -545,7 +545,7 @@ rID Game::GetTempID(uint16 Types, rID mID, int8 maxCR)
                     */
 
           for (spread = 0; 
-               spread < max(Modules[q]->QTem[i].CR.Adjust(tm->CR),1);
+               spread < max<int>(Modules[q]->QTem[i].CR.Adjust(tm->CR),1);
                spread++)
                 Candidates[n++] = Modules[q]->TemplateID(i);
         }

--- a/src/Res.cpp
+++ b/src/Res.cpp
@@ -328,7 +328,7 @@ rID Game::Find(const char*str)
         if (xID = Modules[q]->FindResource(str))
           {
             memmove(&FindCache[1],&FindCache[0],sizeof(__FindCache)*127);
-            szFindCache = min(127,szFindCache+1);
+            szFindCache = std::min(127,szFindCache+1);
             strncpy(FindCache[0].str,str,31);
             FindCache[0].xID = xID;
             return xID;
@@ -545,7 +545,7 @@ rID Game::GetTempID(uint16 Types, rID mID, int8 maxCR)
                     */
 
           for (spread = 0; 
-               spread < max<int>(Modules[q]->QTem[i].CR.Adjust(tm->CR),1);
+               spread < std::max<int>(Modules[q]->QTem[i].CR.Adjust(tm->CR),1);
                spread++)
                 Candidates[n++] = Modules[q]->TemplateID(i);
         }
@@ -622,7 +622,7 @@ rID Game::GetEffectID(int16 Purpose, int8 minlev, int8 maxlev, int8 Source) {
                     continue;
 
                 if (TEFF(effID)->ef.aval == AR_POISON) {
-                    if (p->HasSkill(SK_ALCHEMY) && p->HasSkill(SK_POISON_USE) && (min(p->SkillLevel(SK_ALCHEMY), p->SkillLevel(SK_POISON_USE)) >= TEFF(effID)->ef.sval))
+                    if (p->HasSkill(SK_ALCHEMY) && p->HasSkill(SK_POISON_USE) && (std::min(p->SkillLevel(SK_ALCHEMY), p->SkillLevel(SK_POISON_USE)) >= TEFF(effID)->ef.sval))
                         ;
                     else
                         continue;

--- a/src/Sheet.cpp
+++ b/src/Sheet.cpp
@@ -55,7 +55,7 @@ void TextTerm::CreateCharSheet(CharSheet &cs)
     cs.Basics += Format("%cFaith  %c%s\n",-WHITE,-PURPLE,
         NAME(p->GodID));
   cs.Basics += Format("%cXP     %c%d\n",-WHITE,-PURPLE,
-      max(0,p->XP - p->XP_Drained));
+      max<int>(0,p->XP - p->XP_Drained));
   if (p->XP_Drained) 
     cs.Basics += Format("%c Drain %c%d\n",-WHITE,-PURPLE,
         p->XP_Drained);
@@ -529,11 +529,11 @@ void TextTerm::CreateCharSheet(CharSheet &cs)
           break;
 
         case CA_WEAPON_SKILL:
-          str += Format(":\n  %s",WSkillLevels[min(k,6)]);
+          str += Format(":\n  %s",WSkillLevels[min<int>(k,6)]);
          break;
         case CA_LORE_OF_ARMS:
-          str += Format(" (%d hit%s)",NeededSwings[ min(9,k) ],
-            NeededSwings[ min(9,k) ] > 1 ? "s" : "");
+          str += Format(" (%d hit%s)",NeededSwings[ min<int>(9,k) ],
+            NeededSwings[ min<int>(9,k) ] > 1 ? "s" : "");
          break; 
         case CA_INFRAVISION: case CA_LOWLIGHT:
         case CA_TELEPATHY:   case CA_BLINDSIGHT:

--- a/src/Sheet.cpp
+++ b/src/Sheet.cpp
@@ -55,7 +55,7 @@ void TextTerm::CreateCharSheet(CharSheet &cs)
     cs.Basics += Format("%cFaith  %c%s\n",-WHITE,-PURPLE,
         NAME(p->GodID));
   cs.Basics += Format("%cXP     %c%d\n",-WHITE,-PURPLE,
-      max<int>(0,p->XP - p->XP_Drained));
+      std::max<int>(0,p->XP - p->XP_Drained));
   if (p->XP_Drained) 
     cs.Basics += Format("%c Drain %c%d\n",-WHITE,-PURPLE,
         p->XP_Drained);
@@ -529,11 +529,11 @@ void TextTerm::CreateCharSheet(CharSheet &cs)
           break;
 
         case CA_WEAPON_SKILL:
-          str += Format(":\n  %s",WSkillLevels[min<int>(k,6)]);
+          str += Format(":\n  %s",WSkillLevels[std::min<int>(k,6)]);
          break;
         case CA_LORE_OF_ARMS:
-          str += Format(" (%d hit%s)",NeededSwings[ min<int>(9,k) ],
-            NeededSwings[ min<int>(9,k) ] > 1 ? "s" : "");
+          str += Format(" (%d hit%s)",NeededSwings[std::min<int>(9,k) ],
+            NeededSwings[std::min<int>(9,k) ] > 1 ? "s" : "");
          break; 
         case CA_INFRAVISION: case CA_LOWLIGHT:
         case CA_TELEPATHY:   case CA_BLINDSIGHT:
@@ -614,7 +614,7 @@ void TextTerm::CreateCharSheet(CharSheet &cs)
           if (k) str += Format(" (%d%%)",k*5);
           break;
         case CA_UNBIND:
-          str += Format(" (%d feet)", max(1,k+p->Mod(A_CHA))*10);
+          str += Format(" (%d feet)", std::max(1,k+p->Mod(A_CHA))*10);
         default: 
           ;
 
@@ -1143,7 +1143,7 @@ void TextTerm::CreateCharSheet(CharSheet &cs)
       if (favPen + TGOD(gID)->GetConst(INTERVENTION_COST) > 100)
         cs.sSpiritual += XPrint("<Res> will aid you no further.",gID);
       else
-        cs.sSpiritual += XPrint(FavourPen[min(10,(favPen+9)/10)],gID);
+        cs.sSpiritual += XPrint(FavourPen[std::min(10,(favPen+9)/10)],gID);
       cs.sSpiritual += Format("\n____(Favour %d, Lev %d, Pen %d~)",
                               fv, p->getGodLevel(gID), favPen);
       cs.sSpiritual += "\n";
@@ -1161,12 +1161,12 @@ void TextTerm::CreateCharSheet(CharSheet &cs)
     }
   
   cs.sSpiritual += "__";
-  cs.sSpiritual += XPrint(AlignStrength[min(17,abs(p->alignGE)/4)],
+  cs.sSpiritual += XPrint(AlignStrength[std::min(17,abs(p->alignGE)/4)],
         p->alignGE > 0 ? "Evil" : "Good",
         p->alignGE > 0 ? "Evil" : "Good",
         "Good and Evil");
   cs.sSpiritual += "\n__";
-  cs.sSpiritual += XPrint(AlignStrength[min(17,abs(p->alignLC)/4)],
+  cs.sSpiritual += XPrint(AlignStrength[std::min(17,abs(p->alignLC)/4)],
         p->alignLC > 0 ? "Chaotic" : "Lawful",
         p->alignLC > 0 ? "Chaos" : "Law",
         "Law and Chaos");   
@@ -1258,7 +1258,7 @@ String & Detable(const char*_s, int8 mode)
     String s, s2; int32 i;
     s = _s;
     Again:
-    i = max(s.strchr(WRAP_INDENT),s.strchr(WRAP_BREAK));
+    i = std::max(s.strchr(WRAP_INDENT),s.strchr(WRAP_BREAK));
 
     if (!i)
       return *tmpstr(s);

--- a/src/Skills.cpp
+++ b/src/Skills.cpp
@@ -783,12 +783,12 @@ int8 Creature::SkillKitMod(int16 sk) {
 		}
 
 		if (sk == SK_CLIMB && it->HasIFlag(IT_ROPE))
-			rope_mod = max(rope_mod, (int16)TITEM(it->iID)->GetConst(ROPE_MOD));
+			rope_mod = std::max(rope_mod, (int16)TITEM(it->iID)->GetConst(ROPE_MOD));
 	next_item:;
 	}
 
 	if (HasStati(INNATE_KIT, sk))
-		best = max(best, GetStatiMag(INNATE_KIT, sk));
+		best = std::max(best, GetStatiMag(INNATE_KIT, sk));
 
 	return best + sec + rope_mod;
 }
@@ -957,7 +957,7 @@ void Character::UseSkill(uint8 sk) {
 							DirToGroup[j] = DirTo(
 								posse[i]->x, posse[i]->y) + 10;
 						if (Nearest[j])
-							Nearest[j] = min(Nearest[j],
+							Nearest[j] = std::min(Nearest[j],
 								dist(x, y, posse[i]->x, posse[i]->y));
 						else
 							Nearest[j] =
@@ -1103,7 +1103,7 @@ void Character::UseSkill(uint8 sk) {
 		StatiIterNature(this, SPECIES_AFFINITY)
 			if (e.EVictim->isMType(S->Val))
 			{
-				e.EParam = max(e.EParam, S->Mag);
+				e.EParam = std::max(e.EParam, S->Mag);
 				StatiIterBreakout(this, goto ValidTarget)
 			}
 		StatiIterEnd(this)
@@ -1352,7 +1352,7 @@ void Character::UseSkill(uint8 sk) {
 			else if (GetStatiDur(BLINDNESS) < -1) /* Days */
 				healDC = 25;
 			else
-				healDC = min(10 + GetStatiDur(BLINDNESS) / 3, 20);
+				healDC = std::min(10 + GetStatiDur(BLINDNESS) / 3, 20);
 			if (SkillCheck(SK_HEAL, healDC, true)) {
 				RemoveStati(BLINDNESS);
 				IPrint("You manage to restore your sight.");
@@ -1539,8 +1539,8 @@ bool Creature::SkillCheck(int16 sk, int16 DC, bool show, int16 mod1, const char*
 			rollC = Dice::Roll(1, 20);
 	StatiIterEnd(this)
 
-	roll = max(rollA, rollB);
-	roll = max(roll, rollC);
+	roll = std::max(rollA, rollB);
+	roll = std::max(roll, rollC);
 
 	if (HasAbility(CA_SKILL_MASTERY))
 	{
@@ -1548,7 +1548,7 @@ bool Creature::SkillCheck(int16 sk, int16 DC, bool show, int16 mod1, const char*
 		rID rogueID = FIND("rogue");
 		ASSERT(rogueID);
 		if (TCLASS(rogueID)->HasSkill(sk))
-			roll = max<int>(roll, min(15, 7 + Mod(A_INT)));
+			roll = std::max<int>(roll, std::min(15, 7 + Mod(A_INT)));
 	}
 
 
@@ -1579,7 +1579,7 @@ bool Creature::SkillCheck(int16 sk, int16 DC, bool show, int16 mod1, const char*
 				if (vic->ResistLevel(AD_MIND) == -1)
 					sk -= HighStatiMag(SKILL_BONUS, sk);
 				else
-					sk -= min<int>(HighStatiMag(SKILL_BONUS, sk),
+					sk -= std::min<int>(HighStatiMag(SKILL_BONUS, sk),
 						vic->ResistLevel(AD_MIND) +
 						vic->HighStatiMag(SAVE_BONUS, SN_ENCH));
 			}
@@ -1712,7 +1712,7 @@ bool Creature::SkillCheck(int16 sk, int16 DC, bool show, int16 mod1, const char*
 								goto OnTheList;
 						continue;
 					OnTheList:
-						gainFavour(GodIDList[i], max(0, 10 * (sr + roll + mod1 +
+						gainFavour(GodIDList[i], std::max(0, 10 * (sr + roll + mod1 +
 							mod2 + armPen - 15)), false, true);
 					}
 				}
@@ -1806,13 +1806,13 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 		if (e.EVictim->isMType(MA_UNDEAD)) {
 			VPrint(e, "Holy energy sears you!",
 				"Holy energy sears the <EVictim>!");
-			ThrowDmg(EV_DAMAGE, AD_HOLY, Dice::Roll(2, 6) + max(1, 2 + Mod(A_CHA))*AbilityLevel(CA_LAY_ON_HANDS),
+			ThrowDmg(EV_DAMAGE, AD_HOLY, Dice::Roll(2, 6) + std::max(1, 2 + Mod(A_CHA))*AbilityLevel(CA_LAY_ON_HANDS),
 				"a paladin's touch", this, e.EVictim);
 		}
 		else if (e.EVictim->isMType(MA_LIVING) &&
 			e.EVictim->cHP != (e.EVictim->mHP + e.EVictim->Attr[A_THP])) {
-			e.EVictim->cHP = min(e.EVictim->mHP + e.EVictim->Attr[A_THP],
-				e.EVictim->cHP + Dice::Roll(2, 6) + max(1, 2 + Mod(A_CHA))*AbilityLevel(CA_LAY_ON_HANDS));
+			e.EVictim->cHP = std::min(e.EVictim->mHP + e.EVictim->Attr[A_THP],
+				e.EVictim->cHP + Dice::Roll(2, 6) + std::max(1, 2 + Mod(A_CHA))*AbilityLevel(CA_LAY_ON_HANDS));
 			VPrint(e, "Your wounds heal<Str>!", "The <EVictim>'s wounds heal<Str>!",
 				e.EVictim->cHP == e.EVictim->mHP + e.EVictim->Attr[A_THP] ? " fully" : "");
 		}
@@ -1873,7 +1873,7 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 			"The <Obj> flies into a killing fury!", this);
 		break;
 	case CA_TRACKING:
-		j = max(1, Mod(A_WIS) + 1 + (AbilityLevel(CA_TRACKING) / 5));
+		j = std::max(1, Mod(A_WIS) + 1 + (AbilityLevel(CA_TRACKING) / 5));
 		k = 0;
 		StatiIter(this)
 			if (S->Nature == TRACKING)
@@ -1886,7 +1886,7 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 		targ = thisp->MyTerm->ChooseTarget();
 		if (targ == NULL || targ == this)
 			break;
-		GainPermStati(TRACKING, targ, SS_MISC, 0, min(125, 40 + AbilityLevel(CA_TRACKING) * 5));
+		GainPermStati(TRACKING, targ, SS_MISC, 0, std::min(125, 40 + AbilityLevel(CA_TRACKING) * 5));
 		m->Update(targ->x, targ->y);
 		break;
 	case CA_MANIFESTATION:
@@ -1921,7 +1921,7 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 		DPrint(e, "You invoke the liberating power of <Str>!",
 			"<Obj2> invokes the power of <Str> to free the enslaved!",
 			isCharacter() ? NAME(thisp->GodID) : "Semirath", this);
-		i = max(1, AbilityLevel(CA_UNBIND) + Mod(A_CHA));
+		i = std::max(1, AbilityLevel(CA_UNBIND) + Mod(A_CHA));
 
 		if (PossiblyPause(T1, x, y, 0)) {
 			for (cx = x - i; cx <= x + i; cx++)
@@ -2018,12 +2018,12 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 			return;
 		Timeout += 15;
 
-		bonus = max<int>(1, Mod(A_CHA));
+		bonus = std::max<int>(1, Mod(A_CHA));
 		if (isCharacter())
 			if (thisp->Level[1] || thisp->Level[2])
-				bonus = max(bonus, thisp->LevelAs(FIND("bard")));
+				bonus = std::max(bonus, thisp->LevelAs(FIND("bard")));
 
-		GainTempStati(SINGING, NULL, 5 + (max<int>(0, Mod(A_CON)) + SkillLevel(SK_PERFORM)) * 3, SS_MISC, song, range, 0);
+		GainTempStati(SINGING, NULL, 5 + (std::max<int>(0, Mod(A_CON)) + SkillLevel(SK_PERFORM)) * 3, SS_MISC, song, range, 0);
 
 		switch (song) {
 		case BARD_COURAGE:
@@ -2194,7 +2194,7 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 		}
 		if (!LoseFatigue(1, true))
 			return;
-		cHP = min(mHP + Attr[A_THP], cHP + TotalLevel() * 3);
+		cHP = std::min(mHP + Attr[A_THP], cHP + TotalLevel() * 3);
 		IPrint("Your wounds heal<Str>.", (cHP == mHP + Attr[A_THP]) ? " fully" : "");
 		IDPrint(NULL, "The <Obj>'s wounds heal<Str>.", this,
 			(cHP == mHP + Attr[A_THP]) ? " fully" : "");
@@ -2206,7 +2206,7 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 		}
 		if (!LoseFatigue(1, true))
 			return;
-		GainTempStati(FLURRYING, NULL, 10 + max<int>(0, Mod(A_CON)), SS_MISC);
+		GainTempStati(FLURRYING, NULL, 10 + std::max<int>(0, Mod(A_CON)), SS_MISC);
 		return;
 	case CA_WILD_SHAPE:
 		if (isPlayer())
@@ -2298,7 +2298,7 @@ bool Creature::UseLimitedFA()
 	if (HasFeat(FT_RESIST_PARALYSIS))
 		i += Mod(A_CON) * 2;
 	j = GetStatiVal(LFA_COUNT);
-	if (max<int>(j, 0) >= i)
+	if (std::max<int>(j, 0) >= i)
 		return false;
 	IDPrint("You overcome the paralysis effect. (<Num> left).",
 		"The <Obj2> overcomes the paralysis effect.",
@@ -2512,7 +2512,7 @@ EvReturn Creature::Research(EventInfo &e)
 		cCount = 0; cLevel = 0;
 		StatiIter(this)
 			if (S->Source == SS_CURS) {
-				cLevel = max(cLevel, (int16)S->CLev);
+				cLevel = std::max(cLevel, (int16)S->CLev);
 				cCount++;
 			}
 		StatiIterEnd(this)
@@ -2684,7 +2684,7 @@ EvReturn Creature::PickPocket(EventInfo &e) {
 			Candidates[c++] = it->myHandle;
 			if (isPlayer())
 			{
-				mod = max(0, (it->Size() - SZ_SMALL) * 3);
+				mod = std::max(0, (it->Size() - SZ_SMALL) * 3);
 				if (it->IFlags & IF_WORN)
 					mod += 10;
 				if (e.EVictim->HasStati(DISTRACTED))
@@ -2721,7 +2721,7 @@ EvReturn Creature::PickPocket(EventInfo &e) {
 		h = Candidates[random(c)];
 	it = oItem(h);
 
-	mod = max(0, (it->Size() - SZ_SMALL) * 3);
+	mod = std::max(0, (it->Size() - SZ_SMALL) * 3);
 	if (it->IFlags & IF_WORN)
 		mod += 10;
 	if (e.EVictim->HasStati(DISTRACTED))
@@ -2975,9 +2975,9 @@ MA_MYTHIC,        // 1 hobbit: 18
 		lev = m->ResistLevel(Resists[i]);
 		// ResistLevel tends to give values like 7+CR/2
 		if (lev == -1) // immunity
-			lev = max(CR, 0) + 3;
+			lev = std::max(CR, 0) + 3;
 		else if (lev > 0)
-			lev = max(CR, 0) + 1;
+			lev = std::max(CR, 0) + 1;
 		else
 			continue;
 
@@ -2989,7 +2989,7 @@ MA_MYTHIC,        // 1 hobbit: 18
 		StatiIterEnd(this)
 
 		if (TMON(tmID)->Res & BIT(Resists[i]))
-			curr = max<int>(curr, 7 + (ChallengeRating() * 2) / 3);
+			curr = std::max<int>(curr, 7 + (ChallengeRating() * 2) / 3);
 		if (TMON(tmID)->Imm & BIT(Resists[i]))
 			curr = -1;
 
@@ -3176,7 +3176,7 @@ EvReturn Character::CraftItem(int16 abil) {
 			useSkill = SK_POISON_USE;
 		else
 			useSkill = SK_ALCHEMY;
-		max_lev = min(SkillLevel(SK_POISON_USE), SkillLevel(SK_ALCHEMY));
+		max_lev = std::min(SkillLevel(SK_POISON_USE), SkillLevel(SK_ALCHEMY));
 		goto Create;
 	case FT_SCRIBE_SCROLL + FEAT_VAL:
 		itemType = T_SCROLL;
@@ -3443,7 +3443,7 @@ Augment:
 
 
 		if (HasAbility(CA_MASTER_ARTISAN))
-			gpCost = (gpCost * max(4, 20 - AbilityLevel(CA_MASTER_ARTISAN))) / 20;
+			gpCost = (gpCost * std::max(4, 20 - AbilityLevel(CA_MASTER_ARTISAN))) / 20;
 
 		if (getTotalMoney() / 100 < gpCost) {
 			IPrint(Format("That would cost %d gp in materials, but you only have %d gp.",
@@ -3451,7 +3451,7 @@ Augment:
 			return ABORT;
 		}
 
-		hours = min(10, 2 + (new_lev - old_lev) * 2);
+		hours = std::min(10, 2 + (new_lev - old_lev) * 2);
 		if (HasFeat(FT_ARTIFICER))
 			XPCost = (XPCost * 2) / 3;
 		if (!yn(Format("That will cost %d XP, %d gp and take %d hours. Proceed?",
@@ -3509,11 +3509,11 @@ Create:
 
 	if (acqVal == ACQ_CRAFT) {
 		minSkill = 0;
-		minSkill = max(minSkill, (int16)TITEM(it->iID)->GetConst(MIN_CRAFT_LEVEL));
+		minSkill = std::max(minSkill, (int16)TITEM(it->iID)->GetConst(MIN_CRAFT_LEVEL));
 		if (it->eID)
-			minSkill = max(minSkill, (int16)TITEM(it->eID)->GetConst(MIN_CRAFT_LEVEL));
+			minSkill = std::max(minSkill, (int16)TITEM(it->eID)->GetConst(MIN_CRAFT_LEVEL));
 		if (it->isMetallic()) {
-			minSkill = max<int>(minSkill, 10);
+			minSkill = std::max<int>(minSkill, 10);
 			if (!foundForge) {
 				delete it;
 				IPrint("You need a forge to create metallic items.");
@@ -3526,7 +3526,7 @@ Create:
 				minSkill, SkillLevel(SK_CRAFT)));
 			return ABORT;
 		}
-		craftDC = max<int>(craftDC, minSkill + 7);
+		craftDC = std::max<int>(craftDC, minSkill + 7);
 	}
 
 	quan = 1;
@@ -3556,10 +3556,10 @@ Create:
 	else
 		craftDC += it->ItemLevel();
 
-	XPCost = XPCostTable[min(20, max<int>(it->ItemLevel(), 1))];
+	XPCost = XPCostTable[std::min(20, std::max<int>(it->ItemLevel(), 1))];
 	rID icList[10];
 	if (it->eID && TEFF(it->eID)->GetList(ITEM_COST, icList, 9))
-		XPCost = icList[max(0, it->GetInherentPlus() - 1)] / 25;
+		XPCost = icList[std::max(0, it->GetInherentPlus() - 1)] / 25;
 
 	if (itemType == T_MISSILE)
 		XPCost /= 20;
@@ -3603,7 +3603,7 @@ Create:
 	}
 
 	if (HasAbility(CA_MASTER_ARTISAN))
-		gpCost = (gpCost * max(4, 20 - AbilityLevel(CA_MASTER_ARTISAN))) / 20;
+		gpCost = (gpCost * std::max(4, 20 - AbilityLevel(CA_MASTER_ARTISAN))) / 20;
 
 	if (getTotalMoney() / 100 < gpCost) {
 		IPrint(Format("That would cost %d gp in materials, but you only have %d gp.",
@@ -3703,7 +3703,7 @@ Repair:
 	gpCost /= 30;
 
 	if (HasAbility(CA_MASTER_ARTISAN))
-		gpCost = (gpCost * max(4, 20 - AbilityLevel(CA_MASTER_ARTISAN))) / 20;
+		gpCost = (gpCost * std::max(4, 20 - AbilityLevel(CA_MASTER_ARTISAN))) / 20;
 
 	if (getTotalMoney() / 100 < gpCost) {
 		IPrint(Format("That would cost %d gp in materials, but you only have %d gp.", gpCost, getTotalMoney() / 100));
@@ -3861,7 +3861,7 @@ int16 Creature::getFavEnemyBonus(Creature *cr)
 	StatiIterNature(this, FAV_ENEMY)
 		if (cr->isMType(S->Val)) {
 			v = S->Mag;
-			bonus = max(bonus, CalcFEBonus(S->Val, S->Mag));
+			bonus = std::max(bonus, CalcFEBonus(S->Val, S->Mag));
 		}
 	StatiIterEnd(this)
 	return bonus;
@@ -4243,7 +4243,7 @@ EvReturn Creature::Mount(EventInfo &e) {
 			 * hostilities.*/
 			IPrint("The <Obj1> will not let you ride <him:Obj1>, at least not yet.", e.EVictim); return ABORT;
 		}
-		else if (e.EVictim->ChallengeRating() > 2 && e.EVictim->ChallengeRating() > max(1, SkillLevel(SK_RIDE) / 2) && !(e.EVictim->GetStatiObj(ANIMAL_COMPANION) == this)) {
+		else if (e.EVictim->ChallengeRating() > 2 && e.EVictim->ChallengeRating() > std::max(1, SkillLevel(SK_RIDE) / 2) && !(e.EVictim->GetStatiObj(ANIMAL_COMPANION) == this)) {
 			IPrint("You fear that creature is too mighty to be handled well with your current degree of riding skill.");
 			return ABORT;
 		}
@@ -4510,7 +4510,7 @@ HasComponent:
 					printed = false;
 					e.EVictim = c;
 					int roll = Dice::Roll(1, 20);
-					int resist = (max(e.EVictim->ChallengeRating() + e.EVictim->AbilityLevel(CA_TURN_RESISTANCE), 1));
+					int resist = (std::max(e.EVictim->ChallengeRating() + e.EVictim->AbilityLevel(CA_TURN_RESISTANCE), 1));
 
 					mag = ((e.vDmg + roll) * 750) / (resist * 100);
 
@@ -4711,7 +4711,7 @@ DoDig:
 	percent = 100 / SkillLevel(SK_MINING);
 	if (m->PercentSI + percent > 100)
 		if (!yn(Format("There is a %d~ chance of collapse! Continue?",
-			min(100, (m->PercentSI + percent) - 100))))
+            std::min(100, (m->PercentSI + percent) - 100))))
 			return ABORT;
 
 	if (Dice::Roll(1, 20) <= fat)
@@ -4737,7 +4737,7 @@ DoDig:
 	}
 	m->PercentSI += percent;
 
-	Exercise(A_STR, Dice::Roll(1, 12) + max(0, hard - 10) / 2, ESTR_MINING, 50);
+	Exercise(A_STR, Dice::Roll(1, 12) + std::max(0, hard - 10) / 2, ESTR_MINING, 50);
 
 	if (feat = m->FFeatureAt(tx, ty))
 	{
@@ -4767,7 +4767,7 @@ DoDig:
 	m->At(tx, ty).Memory = 0;
 	m->VUpdate(tx, ty);
 	IPrint("Done. (<Num>~ structural integrity remaining.)",
-		max(0, 100 - m->PercentSI));
+        std::max(0, 100 - m->PercentSI));
 	return DONE; // ww: previously no return value 
 
 }
@@ -4846,7 +4846,7 @@ void Character::LegendIdent(Item *it) {
 					"you discern that it is in fact <str>!",
 					it, (const char*)it->Name(NA_A | NA_IDENT));
 				it->MakeKnown(KN_MAGIC | KN_CURSE | KN_PLUS);
-				Exercise(A_INT, random(6) + max<int>(1, it->ItemLevel()), EINT_IDENT, 75);
+				Exercise(A_INT, random(6) + std::max<int>(1, it->ItemLevel()), EINT_IDENT, 75);
 			}
 			else
 				IPrint("You fail to translate the runes covering the <Obj>.", it);
@@ -4859,7 +4859,7 @@ void Character::LegendIdent(Item *it) {
 	if (it->isType(T_MUSH) || it->isType(T_HERB))
 		if (HasAbility(CA_NATURE_SENSE)) {
 			it->MakeKnown(0xFF);
-			Exercise(A_INT, random(6) + max<int>(1, it->ItemLevel()), EINT_IDENT, 60);
+			Exercise(A_INT, random(6) + std::max<int>(1, it->ItemLevel()), EINT_IDENT, 60);
 			IPrint("With your flawless knowledge of nature, you immediately "
 				"recognize this <Str> as an <Obj>.", it->isType(T_HERB) ? "herb" :
 				"mushroom", it);
@@ -5126,7 +5126,7 @@ void Player::SummonAnimalCompanion(bool mount)
 	int16 lev = AbilityLevel(mount ? CA_SACRED_MOUNT : CA_ANIMAL_COMP);
 	if (lev <= 0) return;
 	int16 ft_bonus = HasFeat(mount ? FT_IMPROVED_MOUNT : FT_ANIMAL_BOND) ?
-		max(0, Mod(A_CHA) / 3) : (mount ? 0 : -2);
+        std::max(0, Mod(A_CHA) / 3) : (mount ? 0 : -2);
 	int16 i, n, j;
 	Creature *c;
 	rID tID = mount ? FIND("celestial") : FIND("dire");
@@ -5279,7 +5279,7 @@ void Player::SummonAnimalCompanion(bool mount)
 			else {
 				if (okAnimalComp(lev, mID, 0)) {
 					Monster *mon = new Monster(mID);
-					int diff = ((1 + lev + ft_bonus) - max<int>(mon->ChallengeRating(), 0));
+					int diff = ((1 + lev + ft_bonus) - std::max<int>(mon->ChallengeRating(), 0));
 					if (diff < 1) diff = 1;
 					else if (diff > 12) diff = 12;
 					rID tid = FIND(Format("companion;%d", diff));
@@ -5313,7 +5313,7 @@ void Player::SummonAnimalCompanion(bool mount)
 MountMade:
 	mn->PlaceAt(m, x, y);
 	if (!mount) {
-		int diff = ((1 + lev + ft_bonus) - max<int>(mn->ChallengeRating(), 0));
+		int diff = ((1 + lev + ft_bonus) - std::max<int>(mn->ChallengeRating(), 0));
 		if (diff < 1) diff = 1;
 		else if (diff > 12) diff = 12;
 		rID tid = FIND(Format("companion;%d", diff));
@@ -5422,7 +5422,7 @@ bool Creature::okWildShape(int16 lev, rID mID, rID tID)
 #endif
 
 	if (tm->isMType(mID, MA_ELEMENTAL))
-		if (lev >= 12 + max(0, tm->Size - SZ_MEDIUM) * 4)
+		if (lev >= 12 + std::max(0, tm->Size - SZ_MEDIUM) * 4)
 			goto typeOk;
 
 	return false;
@@ -5580,7 +5580,7 @@ bool Creature::ItemPrereq(rID xID, int16 ReqLevel, int16 TrickDC)
 		StatiIterNature(this, SPELL_ACCESS)
 			for (j = 0; types[j]; j++)
 				if (S->Val & (xID - CLEV_VAL) & types[j])
-					clev[j] = max<int>(clev[j], S->Mag);
+					clev[j] = std::max<int>(clev[j], S->Mag);
 		StatiIterEnd(this);
 		return (clev[0] + clev[1] + clev[2] +
 			clev[3] + clev[4]) >= ReqLevel;
@@ -5628,23 +5628,23 @@ int16 Creature::getBestKnowSkill(Creature *cr, bool isCombat)
 	int16 best;
 	best = 0;
 	if (cr->isMType(MA_UNDEAD) && HasSkill(SK_KNOW_UNDEAD))
-		best = max(best, SkillLevel(SK_KNOW_UNDEAD));
+		best = std::max(best, SkillLevel(SK_KNOW_UNDEAD));
 	if (cr->isMType(MA_AQUATIC) && HasSkill(SK_KNOW_OCEANS))
-		best = max(best, SkillLevel(SK_KNOW_OCEANS));
+		best = std::max(best, SkillLevel(SK_KNOW_OCEANS));
 	if (cr->isMType(MA_OUTSIDER) && HasSkill(SK_KNOW_PLANES))
 		if (!(cr->isMType(MA_DEMON) || cr->isMType(MA_DEVIL) ||
 			cr->isMType(MA_CELESTIAL)))
-			best = max(best, SkillLevel(SK_KNOW_PLANES));
+			best = std::max(best, SkillLevel(SK_KNOW_PLANES));
 	if ((cr->isMType(MA_DEMON) || cr->isMType(MA_DEVIL)) &&
 		HasSkill(SK_KNOW_INF))
-		best = max(best, SkillLevel(SK_KNOW_INF));
+		best = std::max(best, SkillLevel(SK_KNOW_INF));
 	if ((cr->isMType(MA_PLANT) || cr->isMType(MA_ANIMAL)) &&
 		HasSkill(SK_KNOW_NATURE))
-		best = max(best, SkillLevel(SK_KNOW_NATURE));
+		best = std::max(best, SkillLevel(SK_KNOW_NATURE));
 	if (cr->isMType(MA_MYTHIC) && HasSkill(SK_KNOW_MYTH))
-		best = max(best, SkillLevel(SK_KNOW_MYTH));
+		best = std::max(best, SkillLevel(SK_KNOW_MYTH));
 	if (cr->isMType(MA_NLIVING) && cr->HasMFlag(M_HUMANOID))
 		if (HasSkill(SK_FIND_WEAKNESS) && isCombat)
-			best = max(best, SkillLevel(SK_FIND_WEAKNESS));
+			best = std::max(best, SkillLevel(SK_FIND_WEAKNESS));
 	return best;
 }

--- a/src/Skills.cpp
+++ b/src/Skills.cpp
@@ -1548,7 +1548,7 @@ bool Creature::SkillCheck(int16 sk, int16 DC, bool show, int16 mod1, const char*
 		rID rogueID = FIND("rogue");
 		ASSERT(rogueID);
 		if (TCLASS(rogueID)->HasSkill(sk))
-			roll = max(roll, min(15, 7 + Mod(A_INT)));
+			roll = max<int>(roll, min(15, 7 + Mod(A_INT)));
 	}
 
 
@@ -1579,7 +1579,7 @@ bool Creature::SkillCheck(int16 sk, int16 DC, bool show, int16 mod1, const char*
 				if (vic->ResistLevel(AD_MIND) == -1)
 					sk -= HighStatiMag(SKILL_BONUS, sk);
 				else
-					sk -= min(HighStatiMag(SKILL_BONUS, sk),
+					sk -= min<int>(HighStatiMag(SKILL_BONUS, sk),
 						vic->ResistLevel(AD_MIND) +
 						vic->HighStatiMag(SAVE_BONUS, SN_ENCH));
 			}
@@ -2018,12 +2018,12 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 			return;
 		Timeout += 15;
 
-		bonus = max(1, Mod(A_CHA));
+		bonus = max<int>(1, Mod(A_CHA));
 		if (isCharacter())
 			if (thisp->Level[1] || thisp->Level[2])
 				bonus = max(bonus, thisp->LevelAs(FIND("bard")));
 
-		GainTempStati(SINGING, NULL, 5 + (max(0, Mod(A_CON)) + SkillLevel(SK_PERFORM)) * 3, SS_MISC, song, range, 0);
+		GainTempStati(SINGING, NULL, 5 + (max<int>(0, Mod(A_CON)) + SkillLevel(SK_PERFORM)) * 3, SS_MISC, song, range, 0);
 
 		switch (song) {
 		case BARD_COURAGE:
@@ -2206,7 +2206,7 @@ void Character::UseAbility(uint8 ab, int16 pa) {
 		}
 		if (!LoseFatigue(1, true))
 			return;
-		GainTempStati(FLURRYING, NULL, 10 + max(0, Mod(A_CON)), SS_MISC);
+		GainTempStati(FLURRYING, NULL, 10 + max<int>(0, Mod(A_CON)), SS_MISC);
 		return;
 	case CA_WILD_SHAPE:
 		if (isPlayer())
@@ -2298,7 +2298,7 @@ bool Creature::UseLimitedFA()
 	if (HasFeat(FT_RESIST_PARALYSIS))
 		i += Mod(A_CON) * 2;
 	j = GetStatiVal(LFA_COUNT);
-	if (max(j, 0) >= i)
+	if (max<int>(j, 0) >= i)
 		return false;
 	IDPrint("You overcome the paralysis effect. (<Num> left).",
 		"The <Obj2> overcomes the paralysis effect.",
@@ -2989,7 +2989,7 @@ MA_MYTHIC,        // 1 hobbit: 18
 		StatiIterEnd(this)
 
 		if (TMON(tmID)->Res & BIT(Resists[i]))
-			curr = max(curr, 7 + (ChallengeRating() * 2) / 3);
+			curr = max<int>(curr, 7 + (ChallengeRating() * 2) / 3);
 		if (TMON(tmID)->Imm & BIT(Resists[i]))
 			curr = -1;
 
@@ -3513,7 +3513,7 @@ Create:
 		if (it->eID)
 			minSkill = max(minSkill, (int16)TITEM(it->eID)->GetConst(MIN_CRAFT_LEVEL));
 		if (it->isMetallic()) {
-			minSkill = max(minSkill, 10);
+			minSkill = max<int>(minSkill, 10);
 			if (!foundForge) {
 				delete it;
 				IPrint("You need a forge to create metallic items.");
@@ -3526,7 +3526,7 @@ Create:
 				minSkill, SkillLevel(SK_CRAFT)));
 			return ABORT;
 		}
-		craftDC = max(craftDC, minSkill + 7);
+		craftDC = max<int>(craftDC, minSkill + 7);
 	}
 
 	quan = 1;
@@ -3556,7 +3556,7 @@ Create:
 	else
 		craftDC += it->ItemLevel();
 
-	XPCost = XPCostTable[min(20, max(it->ItemLevel(), 1))];
+	XPCost = XPCostTable[min(20, max<int>(it->ItemLevel(), 1))];
 	rID icList[10];
 	if (it->eID && TEFF(it->eID)->GetList(ITEM_COST, icList, 9))
 		XPCost = icList[max(0, it->GetInherentPlus() - 1)] / 25;
@@ -4846,7 +4846,7 @@ void Character::LegendIdent(Item *it) {
 					"you discern that it is in fact <str>!",
 					it, (const char*)it->Name(NA_A | NA_IDENT));
 				it->MakeKnown(KN_MAGIC | KN_CURSE | KN_PLUS);
-				Exercise(A_INT, random(6) + max(1, it->ItemLevel()), EINT_IDENT, 75);
+				Exercise(A_INT, random(6) + max<int>(1, it->ItemLevel()), EINT_IDENT, 75);
 			}
 			else
 				IPrint("You fail to translate the runes covering the <Obj>.", it);
@@ -4859,7 +4859,7 @@ void Character::LegendIdent(Item *it) {
 	if (it->isType(T_MUSH) || it->isType(T_HERB))
 		if (HasAbility(CA_NATURE_SENSE)) {
 			it->MakeKnown(0xFF);
-			Exercise(A_INT, random(6) + max(1, it->ItemLevel()), EINT_IDENT, 60);
+			Exercise(A_INT, random(6) + max<int>(1, it->ItemLevel()), EINT_IDENT, 60);
 			IPrint("With your flawless knowledge of nature, you immediately "
 				"recognize this <Str> as an <Obj>.", it->isType(T_HERB) ? "herb" :
 				"mushroom", it);
@@ -5279,7 +5279,7 @@ void Player::SummonAnimalCompanion(bool mount)
 			else {
 				if (okAnimalComp(lev, mID, 0)) {
 					Monster *mon = new Monster(mID);
-					int diff = ((1 + lev + ft_bonus) - max(mon->ChallengeRating(), 0));
+					int diff = ((1 + lev + ft_bonus) - max<int>(mon->ChallengeRating(), 0));
 					if (diff < 1) diff = 1;
 					else if (diff > 12) diff = 12;
 					rID tid = FIND(Format("companion;%d", diff));
@@ -5313,7 +5313,7 @@ void Player::SummonAnimalCompanion(bool mount)
 MountMade:
 	mn->PlaceAt(m, x, y);
 	if (!mount) {
-		int diff = ((1 + lev + ft_bonus) - max(mn->ChallengeRating(), 0));
+		int diff = ((1 + lev + ft_bonus) - max<int>(mn->ChallengeRating(), 0));
 		if (diff < 1) diff = 1;
 		else if (diff > 12) diff = 12;
 		rID tid = FIND(Format("companion;%d", diff));
@@ -5580,7 +5580,7 @@ bool Creature::ItemPrereq(rID xID, int16 ReqLevel, int16 TrickDC)
 		StatiIterNature(this, SPELL_ACCESS)
 			for (j = 0; types[j]; j++)
 				if (S->Val & (xID - CLEV_VAL) & types[j])
-					clev[j] = max(clev[j], S->Mag);
+					clev[j] = max<int>(clev[j], S->Mag);
 		StatiIterEnd(this);
 		return (clev[0] + clev[1] + clev[2] +
 			clev[3] + clev[4]) >= ReqLevel;

--- a/src/Social.cpp
+++ b/src/Social.cpp
@@ -465,7 +465,7 @@ EvReturn Creature::OfferTerms(EventInfo &e) {
                         BestCR = cr->ChallengeRating();
                     cr->GainPermStati(TRIED, this, SS_MISC, SK_INTIMIDATE + EV_COW * 100, 0, 0, 0);
                 }
-            CheckDC += max(0, BestCR);
+            CheckDC += max<int>(0, BestCR);
         }
 
     if (!doGroup) {
@@ -548,7 +548,7 @@ EvReturn Creature::Dismiss(EventInfo &e) {
     if (HasStati(TRIED, SK_DIPLOMACY + EV_DISMISS * 100, e.EActor))
         result = true;
     else {
-        CheckDC = 7 + max(0, e.EVictim->ChallengeRating()) + m->Depth;
+        CheckDC = 7 + max<int>(0, e.EVictim->ChallengeRating()) + m->Depth;
         result = SkillCheck(SK_DIPLOMACY, CheckDC, true);
     }
 
@@ -655,7 +655,7 @@ EvReturn Creature::Enlist(EventInfo &e) {
     }
 
 
-    Total = max(0, thisp->MaxGroupCR(PHD_PARTY)) - thisp->GetGroupCR(PHD_PARTY, e.EVictim->ChallengeRating());
+    Total = max<int>(0, thisp->MaxGroupCR(PHD_PARTY)) - thisp->GetGroupCR(PHD_PARTY, e.EVictim->ChallengeRating());
     if (Total < 0) {
         IPrint("You don't have enough PHD to add that creature to your "
             "party. Dismiss some other party members, raise your Charisma "
@@ -863,7 +863,7 @@ EvReturn Creature::Greet(EventInfo &e) {
         case 4:
             IPrint("You share some heartening war stories with the <Obj>, "
                 "and you feel like you have a second wind!", e.EVictim);
-            cFP = min(GetAttr(A_FAT), cFP + 2);
+            cFP = min<int>(GetAttr(A_FAT), cFP + 2);
             break;
     }
     e.EVictim->GainPermStati(TRIED, e.EActor, SS_MISC, SK_DIPLOMACY + EV_GREET * 100);
@@ -1083,7 +1083,7 @@ EvReturn Creature::Quell(EventInfo &e) {
         e.EActor->Transgress(FIND("Essiah"),5,false,"exploitation");
     }
 
-    CheckDC = 15 + max(0,e.EVictim->ChallengeRating())*3;
+    CheckDC = 15 + max<int>(0,e.EVictim->ChallengeRating())*3;
     if (wasDamaged)
         CheckDC += 5 + ((dmg*10) / e.EVictim->mHP);
 
@@ -1092,7 +1092,7 @@ EvReturn Creature::Quell(EventInfo &e) {
         e.EVictim->isMType(MA_ILLITHID) ||
         e.EVictim->isMType(MA_DRAGON)) &&
         e.EVictim->isMType(MA_EVIL) &&
-        e.EActor->RandGoodInv(100 + max(1,e.EVictim->ChallengeRating()))) {
+        e.EActor->RandGoodInv(100 + max<int>(1,e.EVictim->ChallengeRating()))) {
             CheckDC -= 7;
             wantsTribute = true;
     } else
@@ -1106,7 +1106,7 @@ EvReturn Creature::Quell(EventInfo &e) {
                     "him you have nothing appropriate to give.",e.EVictim);
                 goto Success;
             }
-            it = e.EActor->RandGoodInv(100 + max(1,e.EVictim->ChallengeRating()));
+            it = e.EActor->RandGoodInv(100 + max<int>(1,e.EVictim->ChallengeRating()));
             if (!it) {
                 TPrint(e,"The <EVictim> wants tribute, but you have nothing "
                     "of sufficient value to offer.", "You demand tribute, "
@@ -2042,15 +2042,15 @@ int32 Item::getShopCost(Creature *Buyer, Creature *Seller) {
                 1000000, 1500000, 2000000 };
             if (isType(T_WEAPON) || isType(T_ARMOUR) ||
                 isType(T_SHIELD) || isType(T_BOW))
-                cost += defCost[max(0, min(20, ItemLevel(false)))] * (eID ? 400L : 160L);
+                cost += defCost[max(0, min<int>(20, ItemLevel(false)))] * (eID ? 400L : 160L);
             else
-                cost += defCost[max(0, min(20, ItemLevel(false)))] * 70L;
+                cost += defCost[max(0, min<int>(20, ItemLevel(false)))] * 70L;
         }
     }
 
     if (cost) {
         cost *= Quantity;
-        cost = max(1, cost / 100);
+        cost = max(1.0, cost / 100);
     }
 
     cost /= 3;
@@ -2123,7 +2123,7 @@ int32 Item::getShopCost(Creature *Buyer, Creature *Seller) {
         cost *= BarterPrices[min(index + 10, 40)];
     }
 
-    cost = max(1, cost / 100.0);
+    cost = max(1.0, cost / 100.0);
 
 
     return (int32)cost;
@@ -2494,15 +2494,15 @@ int32 Player::GetGroupXCR(int16 CompType, int16 AddCR) {
        3 fewer HD worth of party members. */
 
     if (CompType == PHD_PARTY) {
-        if (GetGroupCR(PHD_ANIMAL) > max(0, MaxGroupCR(PHD_ANIMAL))) {
+        if (GetGroupCR(PHD_ANIMAL) > max<int>(0, MaxGroupCR(PHD_ANIMAL))) {
             CRCubed += GetGroupXCR(PHD_ANIMAL);
             CRCubed -= MaxGroupXCR(PHD_ANIMAL);
         }
-        if (GetGroupCR(PHD_MAGIC) > max(0, MaxGroupCR(PHD_MAGIC))) {
+        if (GetGroupCR(PHD_MAGIC) > max<int>(0, MaxGroupCR(PHD_MAGIC))) {
             CRCubed += GetGroupXCR(PHD_MAGIC);
             CRCubed -= MaxGroupXCR(PHD_MAGIC);
         }
-        if (GetGroupCR(PHD_COMMAND) > max(0, MaxGroupCR(PHD_COMMAND))) {
+        if (GetGroupCR(PHD_COMMAND) > max<int>(0, MaxGroupCR(PHD_COMMAND))) {
             CRCubed += GetGroupXCR(PHD_COMMAND);
             CRCubed -= MaxGroupXCR(PHD_COMMAND);
         }
@@ -2514,7 +2514,7 @@ int32 Player::GetGroupXCR(int16 CompType, int16 AddCR) {
        bonus undead pool and the normal magic pool to control created
        undead. */
     if (CompType == PHD_MAGIC)
-        if (GetGroupCR(PHD_UNDEAD) > max(0, MaxGroupCR(PHD_UNDEAD))) {
+        if (GetGroupCR(PHD_UNDEAD) > max<int>(0, MaxGroupCR(PHD_UNDEAD))) {
             CRCubed += GetGroupXCR(PHD_UNDEAD);
             CRCubed -= MaxGroupXCR(PHD_UNDEAD);
         }
@@ -2531,18 +2531,18 @@ int16 Player::MaxGroupCR(int16 CompType) {
     switch (CompType) {
     case PHD_PARTY:
         bonus = ((SkillLevel(SK_DIPLOMACY) - 5) / 5) * 2;
-        bonus = max(0, bonus);
+        bonus = max<int>(0, bonus);
         return TotalLevel() + Mod(A_CHA) + bonus + (HasFeat(FT_LEADERSHIP) ? 3 : 0) + HighStatiMag(BONUS_PHD, CompType);
     case PHD_MAGIC:
         return max(0, (CasterLev() + TotalLevel()) / 2) + AbilityLevel(CA_COMMAND_AUTHORITY) + HighStatiMag(BONUS_PHD, CompType);
     case PHD_ANIMAL:
         if (!HasAbility(CA_ANIMAL_COMP))
             return -10;
-        return max(1, AbilityLevel(CA_ANIMAL_COMP)) + HighStatiMag(BONUS_PHD, CompType);
+        return max<int>(1, AbilityLevel(CA_ANIMAL_COMP)) + HighStatiMag(BONUS_PHD, CompType);
     case PHD_COMMAND:
         if (!HasAbility(CA_COMMAND))
             return -10;
-        return max(1, HighStatiMag(COMMAND_ABILITY)) + AbilityLevel(CA_COMMAND_AUTHORITY) + HighStatiMag(BONUS_PHD, CompType);
+        return max<int>(1, HighStatiMag(COMMAND_ABILITY)) + AbilityLevel(CA_COMMAND_AUTHORITY) + HighStatiMag(BONUS_PHD, CompType);
     case PHD_UNDEAD:
         return HighStatiMag(BONUS_PHD, CompType);
     default:

--- a/src/Social.cpp
+++ b/src/Social.cpp
@@ -342,11 +342,11 @@ EvReturn Creature::Cow(EventInfo &e) {
                     cr->GainPermStati(TRIED, this, SS_MISC,
                         SK_INTIMIDATE + EV_COW * 100, 0, 0, 0);
                 }
-            CheckDC += max(0, BestCR * 3);
+            CheckDC += std::max(0, BestCR * 3);
 
         }
     if (!doGroup) {
-        CheckDC += max(0, e.EVictim->ChallengeRating() * 3);
+        CheckDC += std::max(0, e.EVictim->ChallengeRating() * 3);
         e.EVictim->GainPermStati(TRIED, this, SS_MISC,
             SK_INTIMIDATE + EV_COW * 100, 0, 0, 0);
     }
@@ -465,11 +465,11 @@ EvReturn Creature::OfferTerms(EventInfo &e) {
                         BestCR = cr->ChallengeRating();
                     cr->GainPermStati(TRIED, this, SS_MISC, SK_INTIMIDATE + EV_COW * 100, 0, 0, 0);
                 }
-            CheckDC += max<int>(0, BestCR);
+            CheckDC += std::max<int>(0, BestCR);
         }
 
     if (!doGroup) {
-        CheckDC += max(0, e.EVictim->ChallengeRating() * 2);
+        CheckDC += std::max(0, e.EVictim->ChallengeRating() * 2);
         e.EVictim->GainPermStati(TRIED, this, SS_MISC, SK_DIPLOMACY + EV_TERMS * 100, 0, 0, 0);
     }
     Timeout += 30;
@@ -548,7 +548,7 @@ EvReturn Creature::Dismiss(EventInfo &e) {
     if (HasStati(TRIED, SK_DIPLOMACY + EV_DISMISS * 100, e.EActor))
         result = true;
     else {
-        CheckDC = 7 + max<int>(0, e.EVictim->ChallengeRating()) + m->Depth;
+        CheckDC = 7 + std::max<int>(0, e.EVictim->ChallengeRating()) + m->Depth;
         result = SkillCheck(SK_DIPLOMACY, CheckDC, true);
     }
 
@@ -584,7 +584,7 @@ EvReturn Creature::Distract(EventInfo &e) {
             if (cr == e.EActor)
                 continue;
             c++;
-            Res = max(cr->SkillLevel(SK_CONCENT), cr->GetAttr(A_SAV_WILL));
+            Res = std::max(cr->SkillLevel(SK_CONCENT), cr->GetAttr(A_SAV_WILL));
             Res += GetStatiMag(TRIED, SK_BLUFF + EV_DISTRACT * 100, e.EActor);
             if (cr == e.EVictim)
                 sRes = Res;
@@ -655,7 +655,7 @@ EvReturn Creature::Enlist(EventInfo &e) {
     }
 
 
-    Total = max<int>(0, thisp->MaxGroupCR(PHD_PARTY)) - thisp->GetGroupCR(PHD_PARTY, e.EVictim->ChallengeRating());
+    Total = std::max<int>(0, thisp->MaxGroupCR(PHD_PARTY)) - thisp->GetGroupCR(PHD_PARTY, e.EVictim->ChallengeRating());
     if (Total < 0) {
         IPrint("You don't have enough PHD to add that creature to your "
             "party. Dismiss some other party members, raise your Charisma "
@@ -695,7 +695,7 @@ EvReturn Creature::Enlist(EventInfo &e) {
         else
             CheckDC = 25;
 
-        CheckDC += max(0, e.EVictim->ChallengeRating() * 3);
+        CheckDC += std::max(0, e.EVictim->ChallengeRating() * 3);
 
         IPrint("You invite the <Obj> to join your party.", e.EVictim);
 
@@ -759,7 +759,7 @@ EvReturn Creature::FastTalk(EventInfo &e) {
     }
 
     BluffDC = 10 + e.EVictim->ChallengeRating() +
-        max(e.EVictim->SkillLevel(SK_APPRAISE),
+        std::max(e.EVictim->SkillLevel(SK_APPRAISE),
         e.EVictim->SkillLevel(SK_CONCENT));
 
     e.EVictim->GainTempStati(TRIED, e.EActor, 30, SS_MISC,
@@ -818,7 +818,7 @@ EvReturn Creature::Greet(EventInfo &e) {
         IDPrint("You chat with the <Obj>.", "The <Obj2> chats with you.", e.EVictim, e.EActor);
 
     if (e.EActor->isPlayer() && e.EVictim->isMonster() && !e.EVictim->HasStati(TRIED, SK_DIPLOMACY + EV_GREET * 100, e.EActor))
-        switch (random(300) / max(1, (e.EActor->SkillLevel(SK_DIPLOMACY) + getSocialMod(e.EVictim, false)))) {
+        switch (random(300) / std::max(1, (e.EActor->SkillLevel(SK_DIPLOMACY) + getSocialMod(e.EVictim, false)))) {
         case 1:
             IPrint("The <Obj> tells you a bit about the local dungeon layout.",
                 e.EVictim);
@@ -863,7 +863,7 @@ EvReturn Creature::Greet(EventInfo &e) {
         case 4:
             IPrint("You share some heartening war stories with the <Obj>, "
                 "and you feel like you have a second wind!", e.EVictim);
-            cFP = min<int>(GetAttr(A_FAT), cFP + 2);
+            cFP = std::min<int>(GetAttr(A_FAT), cFP + 2);
             break;
     }
     e.EVictim->GainPermStati(TRIED, e.EActor, SS_MISC, SK_DIPLOMACY + EV_GREET * 100);
@@ -1083,7 +1083,7 @@ EvReturn Creature::Quell(EventInfo &e) {
         e.EActor->Transgress(FIND("Essiah"),5,false,"exploitation");
     }
 
-    CheckDC = 15 + max<int>(0,e.EVictim->ChallengeRating())*3;
+    CheckDC = 15 + std::max<int>(0,e.EVictim->ChallengeRating())*3;
     if (wasDamaged)
         CheckDC += 5 + ((dmg*10) / e.EVictim->mHP);
 
@@ -1092,7 +1092,7 @@ EvReturn Creature::Quell(EventInfo &e) {
         e.EVictim->isMType(MA_ILLITHID) ||
         e.EVictim->isMType(MA_DRAGON)) &&
         e.EVictim->isMType(MA_EVIL) &&
-        e.EActor->RandGoodInv(100 + max<int>(1,e.EVictim->ChallengeRating()))) {
+        e.EActor->RandGoodInv(100 + std::max<int>(1,e.EVictim->ChallengeRating()))) {
             CheckDC -= 7;
             wantsTribute = true;
     } else
@@ -1106,7 +1106,7 @@ EvReturn Creature::Quell(EventInfo &e) {
                     "him you have nothing appropriate to give.",e.EVictim);
                 goto Success;
             }
-            it = e.EActor->RandGoodInv(100 + max<int>(1,e.EVictim->ChallengeRating()));
+            it = e.EActor->RandGoodInv(100 + std::max<int>(1,e.EVictim->ChallengeRating()));
             if (!it) {
                 TPrint(e,"The <EVictim> wants tribute, but you have nothing "
                     "of sufficient value to offer.", "You demand tribute, "
@@ -1300,7 +1300,7 @@ EvReturn Creature::Request(EventInfo &e) {
         
         }
     if (!doGroup)
-      DC += max(0,(e.EVictim->ChallengeRating() + (sk != SK_INTIMIDATE ? 0 :
+      DC += std::max(0,(e.EVictim->ChallengeRating() + (sk != SK_INTIMIDATE ? 0 :
                     e.EVictim->GetStatiMag(SAVE_BONUS,SN_FEAR)))*2);
     
     DC += e.EVictim->GetStatiMag(RETRY_BONUS,EV_REQUEST*100,this);
@@ -1750,9 +1750,9 @@ DoneRaceMod:
           if (cr->ResistLevel(AD_MIND) == -1)
             continue;
           if (mag > 0)
-            mag = max(0, mag - cr->HighStatiMag(SAVE_BONUS,SN_ENCH));
+            mag = std::max(0, mag - cr->HighStatiMag(SAVE_BONUS,SN_ENCH));
           else
-            mag = min(0, mag +  cr->HighStatiMag(SAVE_BONUS,SN_ENCH));
+            mag = std::min(0, mag +  cr->HighStatiMag(SAVE_BONUS,SN_ENCH));
         }
       if (mag)
         {
@@ -2019,7 +2019,7 @@ int32 Item::getShopCost(Creature *Buyer, Creature *Seller) {
         cost = 0;
         for (i = 0; i != MAX_SPELLS; i++)
             if (HasSpell(i))
-                cost += max(200, 150 * TEFF(theGame->SpellID(i))->Level);
+                cost += std::max(200, 150 * TEFF(theGame->SpellID(i))->Level);
     }
 
     if (isType(T_SCROLL) || isType(T_POTION)) {
@@ -2042,15 +2042,15 @@ int32 Item::getShopCost(Creature *Buyer, Creature *Seller) {
                 1000000, 1500000, 2000000 };
             if (isType(T_WEAPON) || isType(T_ARMOUR) ||
                 isType(T_SHIELD) || isType(T_BOW))
-                cost += defCost[max(0, min<int>(20, ItemLevel(false)))] * (eID ? 400L : 160L);
+                cost += defCost[std::max(0, std::min<int>(20, ItemLevel(false)))] * (eID ? 400L : 160L);
             else
-                cost += defCost[max(0, min<int>(20, ItemLevel(false)))] * 70L;
+                cost += defCost[std::max(0, std::min<int>(20, ItemLevel(false)))] * 70L;
         }
     }
 
     if (cost) {
         cost *= Quantity;
-        cost = max(1.0, cost / 100);
+        cost = std::max(1.0, cost / 100);
     }
 
     cost /= 3;
@@ -2112,18 +2112,18 @@ int32 Item::getShopCost(Creature *Buyer, Creature *Seller) {
     index = Buyer->SkillLevel(SK_DIPLOMACY);
 
     index += Buyer->getSocialMod(Seller, false);
-    index = max(index, -10);
-    index = min(index, +30);
+    index = std::max(index, -10);
+    index = std::min(index, +30);
 
     if (Seller->HasMFlag(M_SELLER))
         cost *= ShopPrices[index + 10];
     else {
         if (Seller->getLeader() == Buyer)
             index += 10;
-        cost *= BarterPrices[min(index + 10, 40)];
+        cost *= BarterPrices[std::min(index + 10, 40)];
     }
 
-    cost = max(1.0, cost / 100.0);
+    cost = std::max(1.0, cost / 100.0);
 
 
     return (int32)cost;
@@ -2201,8 +2201,8 @@ void Player::WildShape() {
                 continue;
             /* new way: big sizes count as "more hit dice" */
             if (mod->QMon[idx].HitDice +
-                max(mod->QMon[idx].Size - SZ_MEDIUM,0) +
-                max(SZ_SMALL - mod->QMon[idx].Size,0) 
+                std::max(mod->QMon[idx].Size - SZ_MEDIUM,0) +
+                std::max(SZ_SMALL - mod->QMon[idx].Size,0)
         > lev) 
         continue;
             /* old way: you need to be a certain level to get big sizes ...
@@ -2259,7 +2259,7 @@ void Player::SummonDruidAnimal() {
             // ww: later restrict this to animals we have seen at least once
             rID mid = mod->MonsterID(idx);
             Monster *mon = new Monster(mid);
-            int diff = ((1 + lev + ft_bonus) - max(mon->ChallengeRating(),0));
+            int diff = ((1 + lev + ft_bonus) - std::max(mon->ChallengeRating(),0));
             if (diff < 1) diff = 1;
             else if (diff > 12) diff = 12;
             rID tid = FIND(Format("companion;%d",diff));
@@ -2296,7 +2296,7 @@ void Player::SummonDruidAnimal() {
 
     Monster *mn = new Monster(mid);
     mn->PlaceAt(m,x,y);
-    int diff = ((1 + lev + ft_bonus) - max(mn->ChallengeRating(),0));
+    int diff = ((1 + lev + ft_bonus) - std::max(mn->ChallengeRating(),0));
     if (diff < 1) diff = 1;
     else if (diff > 12) diff = 12;
     rID tid = FIND(Format("companion;%d",diff));
@@ -2340,7 +2340,7 @@ void Player::InitCompanions() {
 #if 0
     if (HasAbility(CA_ANIMAL_COMP)) {
         MaxCR = MaxGroupCR(PHD_ANIMAL);
-        MaxCR = max(1,min(TotalLevel()+1,MaxCR));
+        MaxCR = std::max(1, std::min(TotalLevel()+1,MaxCR));
         mID = theGame->GetMonID(PUR_SUMMON,0,MaxCR,MaxCR,MA_ANIMAL);
         if (!mID)
             return;
@@ -2374,7 +2374,7 @@ bool Monster::MakeCompanion(Player *p, int16 CompType) {
     if (CompType != PHD_PARTY)
         Total = XCRtoCR(
         XCR(Total) +
-        max(0, XCR(p->MaxGroupCR(PHD_PARTY)) -
+        std::max(0, XCR(p->MaxGroupCR(PHD_PARTY)) -
         XCR(p->GetGroupCR(PHD_PARTY))));
     if (Total < 0) {
         switch (CompType) {
@@ -2480,12 +2480,12 @@ int32 Player::GetGroupXCR(int16 CompType, int16 AddCR) {
             if (ct != CompType)
                 continue;
             j = c->ChallengeRating();
-            CRCubed += max(10, ((j + 2)*(j + 2)*(j + 2)));
+            CRCubed += std::max(10, ((j + 2)*(j + 2)*(j + 2)));
         }
     }
 
     if (AddCR)
-        CRCubed += max(0, (AddCR + 2) * (AddCR + 2) * (AddCR + 2));
+        CRCubed += std::max(0, (AddCR + 2) * (AddCR + 2) * (AddCR + 2));
 
     /* The CR of party HD includes the CRs of groups that
        overflow into it. For example, a ranger has a 2 HD
@@ -2494,15 +2494,15 @@ int32 Player::GetGroupXCR(int16 CompType, int16 AddCR) {
        3 fewer HD worth of party members. */
 
     if (CompType == PHD_PARTY) {
-        if (GetGroupCR(PHD_ANIMAL) > max<int>(0, MaxGroupCR(PHD_ANIMAL))) {
+        if (GetGroupCR(PHD_ANIMAL) > std::max<int>(0, MaxGroupCR(PHD_ANIMAL))) {
             CRCubed += GetGroupXCR(PHD_ANIMAL);
             CRCubed -= MaxGroupXCR(PHD_ANIMAL);
         }
-        if (GetGroupCR(PHD_MAGIC) > max<int>(0, MaxGroupCR(PHD_MAGIC))) {
+        if (GetGroupCR(PHD_MAGIC) > std::max<int>(0, MaxGroupCR(PHD_MAGIC))) {
             CRCubed += GetGroupXCR(PHD_MAGIC);
             CRCubed -= MaxGroupXCR(PHD_MAGIC);
         }
-        if (GetGroupCR(PHD_COMMAND) > max<int>(0, MaxGroupCR(PHD_COMMAND))) {
+        if (GetGroupCR(PHD_COMMAND) > std::max<int>(0, MaxGroupCR(PHD_COMMAND))) {
             CRCubed += GetGroupXCR(PHD_COMMAND);
             CRCubed -= MaxGroupXCR(PHD_COMMAND);
         }
@@ -2514,7 +2514,7 @@ int32 Player::GetGroupXCR(int16 CompType, int16 AddCR) {
        bonus undead pool and the normal magic pool to control created
        undead. */
     if (CompType == PHD_MAGIC)
-        if (GetGroupCR(PHD_UNDEAD) > max<int>(0, MaxGroupCR(PHD_UNDEAD))) {
+        if (GetGroupCR(PHD_UNDEAD) > std::max<int>(0, MaxGroupCR(PHD_UNDEAD))) {
             CRCubed += GetGroupXCR(PHD_UNDEAD);
             CRCubed -= MaxGroupXCR(PHD_UNDEAD);
         }
@@ -2531,18 +2531,18 @@ int16 Player::MaxGroupCR(int16 CompType) {
     switch (CompType) {
     case PHD_PARTY:
         bonus = ((SkillLevel(SK_DIPLOMACY) - 5) / 5) * 2;
-        bonus = max<int>(0, bonus);
+        bonus = std::max<int>(0, bonus);
         return TotalLevel() + Mod(A_CHA) + bonus + (HasFeat(FT_LEADERSHIP) ? 3 : 0) + HighStatiMag(BONUS_PHD, CompType);
     case PHD_MAGIC:
-        return max(0, (CasterLev() + TotalLevel()) / 2) + AbilityLevel(CA_COMMAND_AUTHORITY) + HighStatiMag(BONUS_PHD, CompType);
+        return std::max(0, (CasterLev() + TotalLevel()) / 2) + AbilityLevel(CA_COMMAND_AUTHORITY) + HighStatiMag(BONUS_PHD, CompType);
     case PHD_ANIMAL:
         if (!HasAbility(CA_ANIMAL_COMP))
             return -10;
-        return max<int>(1, AbilityLevel(CA_ANIMAL_COMP)) + HighStatiMag(BONUS_PHD, CompType);
+        return std::max<int>(1, AbilityLevel(CA_ANIMAL_COMP)) + HighStatiMag(BONUS_PHD, CompType);
     case PHD_COMMAND:
         if (!HasAbility(CA_COMMAND))
             return -10;
-        return max<int>(1, HighStatiMag(COMMAND_ABILITY)) + AbilityLevel(CA_COMMAND_AUTHORITY) + HighStatiMag(BONUS_PHD, CompType);
+        return std::max<int>(1, HighStatiMag(COMMAND_ABILITY)) + AbilityLevel(CA_COMMAND_AUTHORITY) + HighStatiMag(BONUS_PHD, CompType);
     case PHD_UNDEAD:
         return HighStatiMag(BONUS_PHD, CompType);
     default:

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -129,7 +129,7 @@ void Thing::GainTempStati(int16 n, Thing *t, int16 Duration, int8 Cause, int16 V
                 else {
                     __Stati.Removed--;  
                     ASSERT (__Stati.Removed >= 0);
-                    __Stati.Removed = max<int>(0,
+                    __Stati.Removed = std::max<int>(0,
                     __Stati.Removed);
                 }
                 break;
@@ -158,7 +158,7 @@ void Thing::GainTempStati(int16 n, Thing *t, int16 Duration, int8 Cause, int16 V
             ASSERT(__Stati.Allocated <= 256); 
         }
 
-        __max = max<int>(__max,__Stati.Allocated);
+        __max = std::max<int>(__max,__Stati.Allocated);
         ASSERT(__Stati.Last < __Stati.Allocated);
         s = & __Stati.S[__Stati.Last];
         __Stati.Last++;
@@ -267,7 +267,7 @@ void Thing::_FixupStati() {
         if (!num)
             goto SkipMerge;
 
-        newSize = max<int>(2,__Stati.Allocated);
+        newSize = std::max<int>(2,__Stati.Allocated);
         while (newSize <= (__Stati.Last + num + 1))
             newSize *= 2;
 
@@ -887,7 +887,7 @@ void Creature::StatiOff(Status s, bool elapsed) {
             T = ts.GetTarget(oCreature(s.h));
             if (T) {
                 T->why.type = TargetResents;
-                T->priority = max<int>(T->priority,5);
+                T->priority = std::max<int>(T->priority,5);
                 T->type = TargetEnemy;
             }
         } 
@@ -980,7 +980,7 @@ RestartDropItems:
         }
         break;
     case ILLUS_DMG:
-        cHP = max(cHP + s.Mag, mHP + GetAttr(A_THP));
+        cHP = std::max(cHP + s.Mag, mHP + GetAttr(A_THP));
         break;
     case ENRAGED:
     case CONFLICT:
@@ -1356,8 +1356,8 @@ void Map::RemoveField(Field *f) {
         if (f == Fields[i]) {
             Fields.Remove(i);
 
-            for(ix = max(0,cf.cx - cf.rad);ix!=min<int>(sizeX,cf.cx + cf.rad + 1);ix++)
-                for(iy = max(0,cf.cy - cf.rad);iy!=min<int>(sizeY,cf.cy + cf.rad + 1);iy++)
+            for(ix = std::max(0,cf.cx - cf.rad); ix != std::min<int>(sizeX,cf.cx + cf.rad + 1); ix++)
+                for(iy = std::max(0,cf.cy - cf.rad); iy != std::min<int>(sizeY,cf.cy + cf.rad + 1); iy++)
                     if (InBounds(ix,iy)) {
                         At(ix,iy).hasField = FieldAt(ix,iy);
                         if (cf.FType & FI_DARKNESS)
@@ -1426,8 +1426,8 @@ void Map::NewField(int32 FType, int16 x, int16 y, uint8 rad,Glyph Img, int16 Dur
     else
         f->Creator = 0;
 
-    for(ix = max(0,x - rad);ix!=min<int>(sizeX,x + rad + 1);ix++)
-        for(iy = max(0,y - rad);iy!=min<int>(sizeY,y + rad + 1);iy++)
+    for(ix = std::max(0,x - rad); ix != std::min<int>(sizeX,x + rad + 1); ix++)
+        for(iy = std::max(0,y - rad); iy != std::min<int>(sizeY,y + rad + 1); iy++)
             if (f->inArea(ix,iy)) {
                 if (FType & FI_DARKNESS)
                     At(ix,iy).Dark = true;
@@ -1508,8 +1508,8 @@ Restart:
         bool hasMeld = me->HasAbility(CA_EARTHMELD);
         ASSERT(me); 
         n = 0;
-        for(ix = max(0,_cx - f->rad);ix!=min<int>(sizeX,_cx + f->rad + 1);ix++)
-            for(iy = max(0,_cy - f->rad);iy!=min<int>(sizeY,_cy + f->rad + 1);iy++)
+        for(ix = std::max(0,_cx - f->rad); ix != std::min<int>(sizeX,_cx + f->rad + 1); ix++)
+            for(iy = std::max(0,_cy - f->rad); iy != std::min<int>(sizeY,_cy + f->rad + 1); iy++)
                 if ((dist(ix,iy,_cx,_cy) <= f->rad) && !(me->canMoveThrough(NULL,ix,iy,blocked_by))) {
                     if (dist(_cx,_cy,ix,iy) == f->rad) {
                         if (blocked_by && blocked_by->isCreature()) {
@@ -1574,8 +1574,8 @@ Restart:
     f->cx = (uint8)_cx; f->cy = (uint8)_cy;
 
     /* Remove the old field markers... */
-    for(ix = max(0,ox - f->rad);ix!=min<int>(sizeX,ox + f->rad + 1);ix++)
-        for(iy = max(0,oy - f->rad);iy!=min<int>(sizeY,oy + f->rad + 1);iy++)
+    for(ix = std::max(0,ox - f->rad);ix != std::min<int>(sizeX,ox + f->rad + 1); ix++)
+        for(iy = std::max(0,oy - f->rad);iy != std::min<int>(sizeY,oy + f->rad + 1); iy++)
             if (InBounds(ix,iy)) {
                 At(ix,iy).hasField = FieldAt(ix,iy);
                 if (f->FType & FI_DARKNESS)
@@ -1587,8 +1587,8 @@ Restart:
             }
 
     /* And establish new markers. */
-    for(ix = max(0,f->cx - f->rad);ix!=min<int>(sizeX,f->cx + f->rad + 1);ix++)
-        for(iy = max(0,f->cy - f->rad);iy!=min<int>(sizeY,f->cy + f->rad + 1);iy++)
+    for(ix = std::max(0,f->cx - f->rad);ix != std::min<int>(sizeX,f->cx + f->rad + 1); ix++)
+        for(iy = std::max(0,f->cy - f->rad);iy != std::min<int>(sizeY,f->cy + f->rad + 1); iy++)
             if (f->inArea(ix,iy)) {
                 if (f->FType & FI_DARKNESS)
                     At(ix,iy).Dark = true;

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -129,7 +129,7 @@ void Thing::GainTempStati(int16 n, Thing *t, int16 Duration, int8 Cause, int16 V
                 else {
                     __Stati.Removed--;  
                     ASSERT (__Stati.Removed >= 0);
-                    __Stati.Removed = max(0,
+                    __Stati.Removed = max<int>(0,
                     __Stati.Removed);
                 }
                 break;
@@ -158,7 +158,7 @@ void Thing::GainTempStati(int16 n, Thing *t, int16 Duration, int8 Cause, int16 V
             ASSERT(__Stati.Allocated <= 256); 
         }
 
-        __max = max(__max,__Stati.Allocated);
+        __max = max<int>(__max,__Stati.Allocated);
         ASSERT(__Stati.Last < __Stati.Allocated);
         s = & __Stati.S[__Stati.Last];
         __Stati.Last++;
@@ -267,7 +267,7 @@ void Thing::_FixupStati() {
         if (!num)
             goto SkipMerge;
 
-        newSize = max(2,__Stati.Allocated);
+        newSize = max<int>(2,__Stati.Allocated);
         while (newSize <= (__Stati.Last + num + 1))
             newSize *= 2;
 
@@ -887,7 +887,7 @@ void Creature::StatiOff(Status s, bool elapsed) {
             T = ts.GetTarget(oCreature(s.h));
             if (T) {
                 T->why.type = TargetResents;
-                T->priority = max(T->priority,5);
+                T->priority = max<int>(T->priority,5);
                 T->type = TargetEnemy;
             }
         } 
@@ -1356,8 +1356,8 @@ void Map::RemoveField(Field *f) {
         if (f == Fields[i]) {
             Fields.Remove(i);
 
-            for(ix = max(0,cf.cx - cf.rad);ix!=min(sizeX,cf.cx + cf.rad + 1);ix++)
-                for(iy = max(0,cf.cy - cf.rad);iy!=min(sizeY,cf.cy + cf.rad + 1);iy++)
+            for(ix = max(0,cf.cx - cf.rad);ix!=min<int>(sizeX,cf.cx + cf.rad + 1);ix++)
+                for(iy = max(0,cf.cy - cf.rad);iy!=min<int>(sizeY,cf.cy + cf.rad + 1);iy++)
                     if (InBounds(ix,iy)) {
                         At(ix,iy).hasField = FieldAt(ix,iy);
                         if (cf.FType & FI_DARKNESS)
@@ -1426,8 +1426,8 @@ void Map::NewField(int32 FType, int16 x, int16 y, uint8 rad,Glyph Img, int16 Dur
     else
         f->Creator = 0;
 
-    for(ix = max(0,x - rad);ix!=min(sizeX,x + rad + 1);ix++)
-        for(iy = max(0,y - rad);iy!=min(sizeY,y + rad + 1);iy++)
+    for(ix = max(0,x - rad);ix!=min<int>(sizeX,x + rad + 1);ix++)
+        for(iy = max(0,y - rad);iy!=min<int>(sizeY,y + rad + 1);iy++)
             if (f->inArea(ix,iy)) {
                 if (FType & FI_DARKNESS)
                     At(ix,iy).Dark = true;
@@ -1508,8 +1508,8 @@ Restart:
         bool hasMeld = me->HasAbility(CA_EARTHMELD);
         ASSERT(me); 
         n = 0;
-        for(ix = max(0,_cx - f->rad);ix!=min(sizeX,_cx + f->rad + 1);ix++)
-            for(iy = max(0,_cy - f->rad);iy!=min(sizeY,_cy + f->rad + 1);iy++)
+        for(ix = max(0,_cx - f->rad);ix!=min<int>(sizeX,_cx + f->rad + 1);ix++)
+            for(iy = max(0,_cy - f->rad);iy!=min<int>(sizeY,_cy + f->rad + 1);iy++)
                 if ((dist(ix,iy,_cx,_cy) <= f->rad) && !(me->canMoveThrough(NULL,ix,iy,blocked_by))) {
                     if (dist(_cx,_cy,ix,iy) == f->rad) {
                         if (blocked_by && blocked_by->isCreature()) {
@@ -1574,8 +1574,8 @@ Restart:
     f->cx = (uint8)_cx; f->cy = (uint8)_cy;
 
     /* Remove the old field markers... */
-    for(ix = max(0,ox - f->rad);ix!=min(sizeX,ox + f->rad + 1);ix++)
-        for(iy = max(0,oy - f->rad);iy!=min(sizeY,oy + f->rad + 1);iy++)
+    for(ix = max(0,ox - f->rad);ix!=min<int>(sizeX,ox + f->rad + 1);ix++)
+        for(iy = max(0,oy - f->rad);iy!=min<int>(sizeY,oy + f->rad + 1);iy++)
             if (InBounds(ix,iy)) {
                 At(ix,iy).hasField = FieldAt(ix,iy);
                 if (f->FType & FI_DARKNESS)
@@ -1587,8 +1587,8 @@ Restart:
             }
 
     /* And establish new markers. */
-    for(ix = max(0,f->cx - f->rad);ix!=min(sizeX,f->cx + f->rad + 1);ix++)
-        for(iy = max(0,f->cy - f->rad);iy!=min(sizeY,f->cy + f->rad + 1);iy++)
+    for(ix = max(0,f->cx - f->rad);ix!=min<int>(sizeX,f->cx + f->rad + 1);ix++)
+        for(iy = max(0,f->cy - f->rad);iy!=min<int>(sizeY,f->cy + f->rad + 1);iy++)
             if (f->inArea(ix,iy)) {
                 if (f->FType & FI_DARKNESS)
                     At(ix,iy).Dark = true;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -960,13 +960,13 @@ bool TargetSystem::addTarget(Target &newT)
     ;;
   if (i != NUM_TARGETS) {
     t[i] = newT;
-    tCount = max<int>(tCount, i+1);
+    tCount = std::max<int>(tCount, i+1);
     return true; 
     }
   for (i=tCount-1; i>=0; i--) 
     if (t[i].priority <= newT.priority) {
       t[i] = newT;
-      tCount = max<int>(tCount, i+1);
+      tCount = std::max<int>(tCount, i+1);
       return true;
     } 
   return false; 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -960,13 +960,13 @@ bool TargetSystem::addTarget(Target &newT)
     ;;
   if (i != NUM_TARGETS) {
     t[i] = newT;
-    tCount = max(tCount, i+1);
+    tCount = max<int>(tCount, i+1);
     return true; 
     }
   for (i=tCount-1; i>=0; i--) 
     if (t[i].priority <= newT.priority) {
       t[i] = newT;
-      tCount = max(tCount, i+1);
+      tCount = max<int>(tCount, i+1);
       return true;
     } 
   return false; 

--- a/src/Term.cpp
+++ b/src/Term.cpp
@@ -366,7 +366,7 @@ void TextTerm::ShowTraits() {
       Color(RED);
     else 
       Color(SKYBLUE);
-    Write(Format("%ld/%ld",max(0,p->XP - p->XP_Drained), p->NextLevXP()));
+    Write(Format("%ld/%ld",max<int>(0,p->XP - p->XP_Drained), p->NextLevXP()));
     Color (GREY);
     Write(" XP\n");
     if (!p->Opt(OPT_SIDEBAR))
@@ -1020,7 +1020,7 @@ void TextTerm::AdjustMap(int16 vx, int16 vy,bool newmap) {
 
 void TextTerm::ShowThings() {
     int16 i, fx, fy, Per; Thing *t;
-    Rect ViewRange(max(XOff - 15, 0), max(YOff - 15, 0), min(XOff + MSizeX() + 15, m->SizeX()), min(YOff + MSizeY() + 15, m->SizeY()));
+    Rect ViewRange(max(XOff - 15, 0), max(YOff - 15, 0), min<int>(XOff + MSizeX() + 15, m->SizeX()), min<int>(YOff + MSizeY() + 15, m->SizeY()));
     Rect ScreenRect((uint8)XOff, (uint8)YOff, (uint8)(XOff + MSizeX()), (uint8)(YOff + MSizeY()));
 
     /* TODO: Allow Selection of Offscreen Glyphs with EffectPrompt:
@@ -1043,8 +1043,8 @@ void TextTerm::ShowThings() {
         m->Update(OffscreenX[i], OffscreenY[i]);
     OffscreenC = 0;
 
-    int16 sx = min(MSizeX(), m->SizeX() - XOff);
-    int16 sy = min(MSizeY(), m->SizeY() - YOff);
+    int16 sx = min<int>(MSizeX(), m->SizeX() - XOff);
+    int16 sy = min<int>(MSizeY(), m->SizeY() - YOff);
     for (int16 y = 0; y < sy; y++)
         for (int16 x = 0; x < sx; x++) {
             if (!m->InBounds(x + XOff, y + YOff))

--- a/src/Term.cpp
+++ b/src/Term.cpp
@@ -266,12 +266,12 @@ SkipThisOne:;
 
     {
         if (LStatLine.TrueLength() < statiLen)
-            Write(max(1, WinRight() - LStatLine.TrueLength()), 1, LStatLine);
+            Write(std::max(1, WinRight() - LStatLine.TrueLength()), 1, LStatLine);
         else if (MStatLine.TrueLength() < statiLen)
-            Write(max(1, WinRight() - MStatLine.TrueLength()), 1, MStatLine);
+            Write(std::max(1, WinRight() - MStatLine.TrueLength()), 1, MStatLine);
         else {
             SStatLine = SStatLine.TrueLeft(statiLen);
-            Write(max(1, WinRight() - SStatLine.TrueLength()), 1, SStatLine);
+            Write(std::max(1, WinRight() - SStatLine.TrueLength()), 1, SStatLine);
         }
     }
 
@@ -366,7 +366,7 @@ void TextTerm::ShowTraits() {
       Color(RED);
     else 
       Color(SKYBLUE);
-    Write(Format("%ld/%ld",max<int>(0,p->XP - p->XP_Drained), p->NextLevXP()));
+    Write(Format("%ld/%ld", std::max<int>(0,p->XP - p->XP_Drained), p->NextLevXP()));
     Color (GREY);
     Write(" XP\n");
     if (!p->Opt(OPT_SIDEBAR))
@@ -957,8 +957,8 @@ void TextTerm::AdjustMap(int16 vx, int16 vy,bool newmap) {
 		oy=YOff;
 		rx=vx-XOff;
 		ry=vy-YOff;
-		lx = min(6,MSizeX() / 6);
-    ly = min(5,MSizeY() / 5);
+		lx = std::min(6,MSizeX() / 6);
+    ly = std::min(5,MSizeY() / 5);
     
     if (newmap)
       {
@@ -1020,7 +1020,7 @@ void TextTerm::AdjustMap(int16 vx, int16 vy,bool newmap) {
 
 void TextTerm::ShowThings() {
     int16 i, fx, fy, Per; Thing *t;
-    Rect ViewRange(max(XOff - 15, 0), max(YOff - 15, 0), min<int>(XOff + MSizeX() + 15, m->SizeX()), min<int>(YOff + MSizeY() + 15, m->SizeY()));
+    Rect ViewRange(std::max(XOff - 15, 0), std::max(YOff - 15, 0), std::min<int>(XOff + MSizeX() + 15, m->SizeX()), std::min<int>(YOff + MSizeY() + 15, m->SizeY()));
     Rect ScreenRect((uint8)XOff, (uint8)YOff, (uint8)(XOff + MSizeX()), (uint8)(YOff + MSizeY()));
 
     /* TODO: Allow Selection of Offscreen Glyphs with EffectPrompt:
@@ -1043,8 +1043,8 @@ void TextTerm::ShowThings() {
         m->Update(OffscreenX[i], OffscreenY[i]);
     OffscreenC = 0;
 
-    int16 sx = min<int>(MSizeX(), m->SizeX() - XOff);
-    int16 sy = min<int>(MSizeY(), m->SizeY() - YOff);
+    int16 sx = std::min<int>(MSizeX(), m->SizeX() - XOff);
+    int16 sy = std::min<int>(MSizeY(), m->SizeY() - YOff);
     for (int16 y = 0; y < sy; y++)
         for (int16 x = 0; x < sx; x++) {
             if (!m->InBounds(x + XOff, y + YOff))
@@ -1272,10 +1272,10 @@ void TextTerm::ShowMapOverview() {
                     }
 
                 if ((onmap && seen) || force) {
-                    x1 = min(x1, mx);
-                    x2 = max(x2, mx);
-                    y1 = min(y1, my);
-                    y2 = max(y2, my);
+                    x1 = std::min(x1, mx);
+                    x2 = std::max(x2, mx);
+                    y1 = std::min(y1, my);
+                    y2 = std::max(y2, my);
                 }
 
                 if (p->x >= mx && p->y >= my && p->x < mx + mag && p->y < my + mag)
@@ -1485,7 +1485,7 @@ static int16 ViewListPriorityMod(Thing *t) {
       return 5;
       }
     else if (t->isCreature())
-      return max(0,-((Creature*)t)->ChallengeRating()/3);
+      return std::max(0,-((Creature*)t)->ChallengeRating()/3);
     else if (t->isFeature())
       {
         if ((t->isType(T_DOOR)) ||
@@ -2971,12 +2971,12 @@ void TextTerm::Title() {
     int16 i, ox, oy;
     
     ox = (sizeX - 80) / 2;
-    oy = max(0,sizeY - 50) / 2;
+    oy = std::max(0,sizeY - 50) / 2;
     
     SetWin(WIN_SCREEN); Clear();
     for(i=0;IntroScreen[i];i++)
       Write(ox,oy+i,XPrint(IntroScreen[i]));
-    SizeWin(WIN_CUSTOM,WinLeft(),min(i+2,WinBottom()-8),WinRight(),WinBottom());
+    SizeWin(WIN_CUSTOM,WinLeft(), std::min(i+2,WinBottom()-8),WinRight(),WinBottom());
     SetWin(WIN_CUSTOM);
     Clear();
 }
@@ -3145,14 +3145,14 @@ void CFile::FWrite(const void *vp, size_t write_size) {
         data = realloc(data, alloc);
     }
     memcpy(&bytes[pos], vp, write_size);
-    size = max(size, pos + (int32)write_size);
+    size = std::max(size, pos + (int32)write_size);
     pos += write_size;
 }
   
 void CFile::FRead(void *vp, size_t read_size) {
     memset(vp, 0, read_size);
-    memcpy(vp, &bytes[pos], min((int32)read_size, size - pos));
-    pos = min(size, pos + (int32)read_size);
+    memcpy(vp, &bytes[pos], std::min((int32)read_size, size - pos));
+    pos = std::min(size, pos + (int32)read_size);
 }
 
 void CFile::Seek(int32 val, int8 seek_type) {
@@ -3165,7 +3165,7 @@ void CFile::Seek(int32 val, int8 seek_type) {
         alloc = (((pos - 1) / CFILE_DELTA) + 1) * CFILE_DELTA;
         realloc(data, alloc);
     }
-    size = max(pos, size);
+    size = std::max(pos, size);
 }
       
 int32 CFile::CommitCompressed(int32 offset, bool use_lz) {

--- a/src/TextTerm.cpp
+++ b/src/TextTerm.cpp
@@ -137,10 +137,10 @@ void TextTerm::SizeWin(int16 wn, int16 x1, int16 y1, int16 x2, int16 y2)
     ASSERT(x1 >= 0  || x1 == -1)
     ASSERT(x2 <= sizeX || x2 == -1)
     ASSERT(y2 <= sizeY || y2 == -1)
-    if (y1 != -1) Windows[wn].Top =    max<int>(0,y1);
-    if (x1 != -1) Windows[wn].Left =   max<int>(0,x1);
-    if (y2 != -1) Windows[wn].Bottom = min(y2,Windows[WIN_SCREEN].Bottom);
-    if (x2 != -1) Windows[wn].Right =  min(x2,Windows[WIN_SCREEN].Right);
+    if (y1 != -1) Windows[wn].Top = std::max<int>(0,y1);
+    if (x1 != -1) Windows[wn].Left = std::max<int>(0,x1);
+    if (y2 != -1) Windows[wn].Bottom = std::min(y2,Windows[WIN_SCREEN].Bottom);
+    if (x2 != -1) Windows[wn].Right = std::min(x2,Windows[WIN_SCREEN].Right);
   }
 
 void TextTerm::SizeWin(int16 wn, int16 sx, int16 sy)
@@ -294,8 +294,8 @@ NextSeg:
     }
 
     /* Find a good place to break off the segment */
-    len = max(space, (int16)Msg.TrueLeft(space).GetLength());
-    for (; len != max(0, space - 15); len--)
+    len = std::max(space, (int16)Msg.TrueLeft(space).GetLength());
+    for (; len != std::max(0, space - 15); len--)
         if (len > Msg.GetLength() || Msg[len] == ' ' || Msg[len] == '\n')
             break;
     /* No good place, so we have to break a word. */
@@ -434,9 +434,9 @@ void TextTerm::Box(int16 win, int16 flags, int16 cbor, int16 ctxt, const char*te
 	strcat(lbuff, "\n");
 	ch = lbuff; LineLength = BoxLength = Lines = SpaceAt = 0;
 	if (flags & BOX_WIDEBOX)
-		Avail = max((activeWin->Right - activeWin->Left) - 10, 20);
+		Avail = std::max((activeWin->Right - activeWin->Left) - 10, 20);
 	else
-		Avail = max(min((activeWin->Right - activeWin->Left) - 10, 50), 20);
+		Avail = std::max(std::min((activeWin->Right - activeWin->Left) - 10, 50), 20);
 	while (*ch) {
 		if (*ch >= 0)
 			LineLength++;
@@ -475,7 +475,7 @@ FoundSpace:;
 		Save();
 
 	SetWin(WIN_SCREEN);
-	SizeWin(WIN_CUSTOM, BoxLength - 1, min(40, Lines - 2));
+	SizeWin(WIN_CUSTOM, BoxLength - 1, std::min(40, Lines - 2));
 
 	DrawBorder(WIN_CUSTOM, cbor);
 	ClearScroll(true);
@@ -553,12 +553,12 @@ int16 TextTerm::WrapWrite(int16 x, int16 y, const char* _s, int16 x2, int16 maxl
 		s = s.Left(s.GetLength() - 1);
 	GotoXY(x, y); lines = 0; cWrap = 0;
 	while (1) {
-		int space_left_on_this_line = (x2 ? x2 : WinSizeX()) - max(x, cWrap);
+		int space_left_on_this_line = (x2 ? x2 : WinSizeX()) - std::max(x, cWrap);
 		int trueLength = s.GetTrueLength();
 		if (space_left_on_this_line > trueLength) {
 			if (trueLength > 0) { lines++; }
 			Write(s);
-			GotoXY(max(x, cWrap), y + lines);
+			GotoXY(std::max(x, cWrap), y + lines);
 			return lines;
 		}
 		pos = (s.TrueLeft(space_left_on_this_line)).GetLength() - 1;
@@ -577,7 +577,7 @@ int16 TextTerm::WrapWrite(int16 x, int16 y, const char* _s, int16 x2, int16 maxl
 			l = s.Left(pos);
 		}
 		s = s.Right((s.GetLength() - l.GetLength()));
-		lines++; Write(l); GotoXY(max(x, cWrap), y + lines);
+		lines++; Write(l); GotoXY(std::max(x, cWrap), y + lines);
 		if ((y + lines) >= WinSizeY() || lines >= maxlines)
 			return lines;
 		while (s.GetLength() && s[0] == ' ')
@@ -596,7 +596,7 @@ void TextTerm::UpdateScrollArea(int16 _offset, int16 wn) {
 	Clear();
 	offset = _offset == -2 ? offset : _offset;
 	if (offset > ScrollLines - WinSizeY())
-		offset = max(0, ScrollLines - WinSizeY());
+		offset = std::max(0, ScrollLines - WinSizeY());
 	if (offset < 0)
 		offset = 0;
 	for (y = 0; y != WinSizeY(); y++) {
@@ -629,7 +629,7 @@ void TextTerm::HyperTab(int16 wn) {
       return;
 
     /* Get Scroll Win Dimensions */
-    sx = min(SCROLL_WIDTH,Windows[wn].Right - Windows[wn].Left);
+    sx = std::min(SCROLL_WIDTH,Windows[wn].Right - Windows[wn].Left);
     sy = Windows[wn].Bottom - Windows[wn].Top;
 
     /* Where "are we" on the page? */
@@ -716,8 +716,8 @@ void TextTerm::SWrite(const char *text, int16 wn)
   {
     int32 oColor; bool isLink = false; int16 c;
     const char *ch;
-    ScrollLines = max<int>(scy+1,ScrollLines);
-    if (scx > min(SCROLL_WIDTH,Windows[wn].Right-Windows[wn].Left))
+    ScrollLines = std::max<int>(scy+1,ScrollLines);
+    if (scx > std::min(SCROLL_WIDTH,Windows[wn].Right-Windows[wn].Left))
       { scx = 0; scy++; }
     if (scy >= MAX_SCROLL_LINES)
       return;
@@ -734,14 +734,14 @@ void TextTerm::SWrite(const char *text, int16 wn)
             ASSERT(!isLink)
             scy++; ch++; scx = 0;
             cWrap = 0;
-            ScrollLines = max<int>(scy+1,ScrollLines);
+            ScrollLines = std::max<int>(scy+1,ScrollLines);
             if (scy > MAX_SCROLL_LINES)
               return;
             continue;
           }
-        if (scx > min(SCROLL_WIDTH,Windows[wn].Right-Windows[wn].Left))
+        if (scx > std::min(SCROLL_WIDTH,Windows[wn].Right-Windows[wn].Left))
           { scy++; scx = 0;
-            ScrollLines = max<int>(scy+1,ScrollLines);
+            ScrollLines = std::max<int>(scy+1,ScrollLines);
             /*
             if (scy > activeWin->Bottom)
               return;
@@ -839,7 +839,7 @@ int16 TextTerm::SWrapWrite(int16 x, int16 y, const char* _s, int16 x2, int16 wn)
     
     int pos, lines;
     
-    x2 = min<int>(SCROLL_WIDTH,x2);
+    x2 = std::min<int>(SCROLL_WIDTH,x2);
     
     /* Trim Trailing Returns */
     while (s.GetLength() && s[s.GetLength()-1] == '\n')
@@ -848,11 +848,11 @@ int16 TextTerm::SWrapWrite(int16 x, int16 y, const char* _s, int16 x2, int16 wn)
     SGotoXY(x,y); lines = 0; cWrap = 0;
     while(1) {
       PurgeStrings();
-      pos = (x2 ? x2 : min(SCROLL_WIDTH,Windows[wn].Right-Windows[wn].Left)) - max(cWrap,x);
+      pos = (x2 ? x2 : std::min(SCROLL_WIDTH,Windows[wn].Right-Windows[wn].Left)) - std::max(cWrap,x);
       if (pos > s.GetTrueLength() && !s.strchr('\n'))
         {
           lines++; SWrite(s,wn);
-          SGotoXY(max(x,cWrap),y+lines);
+          SGotoXY(std::max(x,cWrap),y+lines);
           return lines;
         }
       pos = (s.TrueLeft(pos)).GetLength()-1;
@@ -870,7 +870,7 @@ int16 TextTerm::SWrapWrite(int16 x, int16 y, const char* _s, int16 x2, int16 wn)
         l = l.Right(l.GetLength()-1);
       lines++; SWrite(l,wn); 
       if (cr) cWrap = 0;
-      SGotoXY(max(x,cWrap),y+lines);
+      SGotoXY(std::max(x,cWrap),y+lines);
       if ((y + lines) >= MAX_SCROLL_LINES)
         return lines;
       }  
@@ -950,11 +950,11 @@ Restart:
         (fl & MENU_2COLS) ? 2 : 1;
 
     Save();
-    Rows = max(1,OptionCount / Cols);
+    Rows = std::max(1,OptionCount / Cols);
     if (Cols > 1)
         if (OptionCount % Cols)
             Rows++;
-    vRows = min((fl & MENU_BORDER) ? 32 : 34,Rows);
+    vRows = std::min((fl & MENU_BORDER) ? 32 : 34,Rows);
     vStart = 0;
 
     DY = 0;
@@ -981,7 +981,7 @@ Restart:
         } else if (!title)
             Width = 4 + szCol * Cols;
         else
-            Width = 2 + max(min<int>(45,strlen(title)),szCol*Cols);
+            Width = 2 + std::max(std::min<int>(45,strlen(title)),szCol*Cols);
         Height = vRows + (title ? DY+1 : 0) + 1;
         if (fl & MENU_LARGEBOX) {
             SetWin(WIN_SCREEN);
@@ -1014,7 +1014,7 @@ Restart:
     tcol -= (activeWin->Bottom - activeWin->Top)+1;
     ASSERT(tcol>1);
     }
-    vRows = min(vRows,tcol);
+    vRows = std::min(vRows,tcol);
     */
 
     do {            
@@ -1045,7 +1045,7 @@ Restart:
         }
         if (fl & MENU_DESC) {
             SetWin(MWin);
-            SizeWin(WIN_MENUDESC, WinLeft(),min(WinTop()+vRows+DY+1,WinBottom()-5),WinRight(),WinBottom());
+            SizeWin(WIN_MENUDESC, WinLeft(), std::min(WinTop()+vRows+DY+1,WinBottom()-5),WinRight(),WinBottom());
         }
 
         /* center things nicely */ 
@@ -1055,9 +1055,9 @@ Restart:
             vStart = c; 
 
         SetWin(MWin);
-        for (i = vStart; i != min<int>(OptionCount, vStart + vRows*Cols); i++) {
+        for (i = vStart; i != std::min<int>(OptionCount, vStart + vRows*Cols); i++) {
             GotoXY(((i - vStart) / vRows)*szCol, ((i - vStart) % vRows) + DY);
-            let[0] = MenuLetters[min(53, i)];
+            let[0] = MenuLetters[std::min(53, i)];
             let[1] = 0;
             if (fl & MENU_QKEY)
                 for (qk=0;qk!=MAX_QKEYS;qk++)
@@ -1142,7 +1142,7 @@ InvalidChar:
                 c -= vRows;
             break;
         case KY_CMD_EAST:
-            if (c + vRows <= min(OptionCount-1,vStart+(vRows*Cols-1)))
+            if (c + vRows <= std::min(OptionCount-1,vStart+(vRows*Cols-1)))
                 c += vRows;
             break;   
         case KY_ENTER:
@@ -1228,7 +1228,7 @@ bool TextTerm::LMultiSelect(uint16 fl, const char* _title,int8 MWin,const char*h
 
     barlen = 5;
     for (i=0;i!=OptionCount;i++)
-        barlen = max<int>(barlen,(int16)Option[i].Text.GetTrueLength()+6);
+        barlen = std::max<int>(barlen,(int16)Option[i].Text.GetTrueLength()+6);
 
 
     if (fl & MENU_SORTED)
@@ -1249,11 +1249,11 @@ Restart:
         (fl & MENU_3COLS) ? 3 :
         (fl & MENU_2COLS) ? 2 : 1;
     Save();
-    Rows = max(1,OptionCount / Cols);
+    Rows = std::max(1,OptionCount / Cols);
     if (Cols > 1)
         if (OptionCount % Cols)
             Rows++;
-    vRows = min<int>((fl & MENU_BORDER) ? 36 : 38,Rows);
+    vRows = std::min<int>((fl & MENU_BORDER) ? 36 : 38,Rows);
     vStart = 0;
 
 
@@ -1286,7 +1286,7 @@ Restart:
         else if (!title)
             Width = 4 + szCol * Cols;
         else
-            Width = 2 + max(min<int>(45,strlen(title)),szCol*Cols);
+            Width = 2 + std::max(std::min<int>(45,strlen(title)),szCol*Cols);
         Height = vRows + (title ? DY+1 : 0) + 1;
         if (fl & MENU_LARGEBOX) {
             SetWin(WIN_SCREEN);
@@ -1323,7 +1323,7 @@ Restart:
     tcol -= (activeWin->Bottom - activeWin->Top)+1;
     ASSERT(tcol>1);
     }
-    vRows = min(vRows,tcol);
+    vRows = std::min(vRows,tcol);
     */
 
 
@@ -1357,7 +1357,7 @@ Restart:
         }
         if (fl & MENU_DESC) {
             SetWin(MWin);
-            SizeWin(WIN_MENUDESC, WinLeft(),min(WinTop()+vRows+DY+1,WinBottom()-5),WinRight(),WinBottom());
+            SizeWin(WIN_MENUDESC, WinLeft(), std::min(WinTop()+vRows+DY+1,WinBottom()-5),WinRight(),WinBottom());
         }
 
         /* center things nicely */ 
@@ -1367,7 +1367,7 @@ Restart:
             vStart = c; 
 
         SetWin(MWin);
-        for(i=vStart;i!=min<int>(OptionCount,vStart+vRows*Cols);i++) {
+        for(i=vStart;i!=std::min<int>(OptionCount,vStart+vRows*Cols);i++) {
             GotoXY(((i-vStart)/vRows)*szCol,((i-vStart)%vRows)+DY);
             Color(WHITE);
             Write(Format("  [%c%c%c] %.*s",-PINK,Option[i].isMarked ? '*' : ' ',-GREY,
@@ -1375,7 +1375,7 @@ Restart:
                 (const char*) Option[i].Text
                 ));
             for (j=((i-vStart)/vRows)*szCol+1+activeWin->Left;
-                j!=((i-vStart)/vRows)*szCol+1+min(barlen,szCol)+activeWin->Left;j++)
+                j!=((i-vStart)/vRows)*szCol+1+std::min(barlen,szCol)+activeWin->Left;j++)
                 APutChar(j,((i-vStart)%vRows)+DY+activeWin->Top,
                 (AGetChar(j,((i-vStart)%vRows)+DY+activeWin->Top) & 0x0FFF) | 
                 ((c == i) ? 0x1000 : 0x0000));
@@ -1434,7 +1434,7 @@ InvalidChar:
                 c -= vRows;
             break;
         case KY_CMD_EAST:
-            if (c + vRows <= min(OptionCount-1,vStart+(vRows*Cols-1)))
+            if (c + vRows <= std::min(OptionCount-1,vStart+(vRows*Cols-1)))
                 c += vRows;
             break;   
         case KY_SPACE:

--- a/src/TextTerm.cpp
+++ b/src/TextTerm.cpp
@@ -137,8 +137,8 @@ void TextTerm::SizeWin(int16 wn, int16 x1, int16 y1, int16 x2, int16 y2)
     ASSERT(x1 >= 0  || x1 == -1)
     ASSERT(x2 <= sizeX || x2 == -1)
     ASSERT(y2 <= sizeY || y2 == -1)
-    if (y1 != -1) Windows[wn].Top =    max(0,y1);
-    if (x1 != -1) Windows[wn].Left =   max(0,x1);
+    if (y1 != -1) Windows[wn].Top =    max<int>(0,y1);
+    if (x1 != -1) Windows[wn].Left =   max<int>(0,x1);
     if (y2 != -1) Windows[wn].Bottom = min(y2,Windows[WIN_SCREEN].Bottom);
     if (x2 != -1) Windows[wn].Right =  min(x2,Windows[WIN_SCREEN].Right);
   }
@@ -716,7 +716,7 @@ void TextTerm::SWrite(const char *text, int16 wn)
   {
     int32 oColor; bool isLink = false; int16 c;
     const char *ch;
-    ScrollLines = max(scy+1,ScrollLines);
+    ScrollLines = max<int>(scy+1,ScrollLines);
     if (scx > min(SCROLL_WIDTH,Windows[wn].Right-Windows[wn].Left))
       { scx = 0; scy++; }
     if (scy >= MAX_SCROLL_LINES)
@@ -734,14 +734,14 @@ void TextTerm::SWrite(const char *text, int16 wn)
             ASSERT(!isLink)
             scy++; ch++; scx = 0;
             cWrap = 0;
-            ScrollLines = max(scy+1,ScrollLines);
+            ScrollLines = max<int>(scy+1,ScrollLines);
             if (scy > MAX_SCROLL_LINES)
               return;
             continue;
           }
         if (scx > min(SCROLL_WIDTH,Windows[wn].Right-Windows[wn].Left))
           { scy++; scx = 0;
-            ScrollLines = max(scy+1,ScrollLines);
+            ScrollLines = max<int>(scy+1,ScrollLines);
             /*
             if (scy > activeWin->Bottom)
               return;
@@ -839,7 +839,7 @@ int16 TextTerm::SWrapWrite(int16 x, int16 y, const char* _s, int16 x2, int16 wn)
     
     int pos, lines;
     
-    x2 = min(SCROLL_WIDTH,x2);
+    x2 = min<int>(SCROLL_WIDTH,x2);
     
     /* Trim Trailing Returns */
     while (s.GetLength() && s[s.GetLength()-1] == '\n')
@@ -923,8 +923,8 @@ int32 TextTerm::LMenu(uint16 fl, const char*_title,int8 MWin,const char*help, in
         (theGame->Opt(OPT_ROGUELIKE)) ? 
         "acdefgimopqrstvwxzACDEFGIMOPQRSTVWXZ                  " :
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ  ";
-    int16 ch, i,c,p,qk, szCol, Rows, Cols, Width, Height, DY;
-    char let[5]; int16 vStart, vRows;
+    int ch, i,c,p,qk, szCol, Rows, Cols, Width, Height, DY;
+    char let[5]; int vStart, vRows;
     String title = _title;
     if (Mode == MO_RECREATE) {
         ASSERT(strncmp(RInf.Rsp[RInf.cRsp].Question,title,31) == 0);
@@ -981,7 +981,7 @@ Restart:
         } else if (!title)
             Width = 4 + szCol * Cols;
         else
-            Width = 2 + max(min(45,(int16)strlen(title)),szCol*Cols);
+            Width = 2 + max(min<int>(45,strlen(title)),szCol*Cols);
         Height = vRows + (title ? DY+1 : 0) + 1;
         if (fl & MENU_LARGEBOX) {
             SetWin(WIN_SCREEN);
@@ -1055,7 +1055,7 @@ Restart:
             vStart = c; 
 
         SetWin(MWin);
-        for (i = vStart; i != min(OptionCount, vStart + vRows*Cols); i++) {
+        for (i = vStart; i != min<int>(OptionCount, vStart + vRows*Cols); i++) {
             GotoXY(((i - vStart) / vRows)*szCol, ((i - vStart) % vRows) + DY);
             let[0] = MenuLetters[min(53, i)];
             let[1] = 0;
@@ -1228,7 +1228,7 @@ bool TextTerm::LMultiSelect(uint16 fl, const char* _title,int8 MWin,const char*h
 
     barlen = 5;
     for (i=0;i!=OptionCount;i++)
-        barlen = max(barlen,(int16)Option[i].Text.GetTrueLength()+6);
+        barlen = max<int>(barlen,(int16)Option[i].Text.GetTrueLength()+6);
 
 
     if (fl & MENU_SORTED)
@@ -1253,7 +1253,7 @@ Restart:
     if (Cols > 1)
         if (OptionCount % Cols)
             Rows++;
-    vRows = min((fl & MENU_BORDER) ? 36 : 38,Rows);
+    vRows = min<int>((fl & MENU_BORDER) ? 36 : 38,Rows);
     vStart = 0;
 
 
@@ -1286,7 +1286,7 @@ Restart:
         else if (!title)
             Width = 4 + szCol * Cols;
         else
-            Width = 2 + max(min(45,(int16)strlen(title)),szCol*Cols);
+            Width = 2 + max(min<int>(45,strlen(title)),szCol*Cols);
         Height = vRows + (title ? DY+1 : 0) + 1;
         if (fl & MENU_LARGEBOX) {
             SetWin(WIN_SCREEN);
@@ -1367,7 +1367,7 @@ Restart:
             vStart = c; 
 
         SetWin(MWin);
-        for(i=vStart;i!=min(OptionCount,vStart+vRows*Cols);i++) {
+        for(i=vStart;i!=min<int>(OptionCount,vStart+vRows*Cols);i++) {
             GotoXY(((i-vStart)/vRows)*szCol,((i-vStart)%vRows)+DY);
             Color(WHITE);
             Write(Format("  [%c%c%c] %.*s",-PINK,Option[i].isMarked ? '*' : ' ',-GREY,

--- a/src/VMachine.cpp
+++ b/src/VMachine.cpp
@@ -40,7 +40,7 @@ extern String & EventName(int16 Ev);
 //#define VERIFY(h,ty,str) ;
 #define MEMORY(a)       (*getMemorySafe(a))
 #define STACK(a)        (*getStackSafe(Regs[63] - a))
-#define VSTACK(a)       (*getStackSafe(max(0,Regs[63]-(a))))
+#define VSTACK(a)       (*getStackSafe(std::max(0,Regs[63]-(a))))
 #define MEMORY_ADDR(a)  (getMemorySafe(a))
 #define STACK_ADDR(a)   (getStackSafe(Regs[63] - a))
 #define GETSTR(ht)      (getStringSafe(ht))
@@ -51,11 +51,11 @@ extern String & EventName(int16 Ev);
 #define REGS(a)   (Regs[a])
 #define MEMORY(a) (Memory[a])
 #define STACK(a)  (Stack[Regs[63]-(a)])
-#define VSTACK(a) (Stack[max(0,Regs[63]-(a))])
+#define VSTACK(a) (Stack[std::max(0,Regs[63]-(a))])
 #define MEMORY_ADDR(a) (Memory + (a))
 #define STACK_ADDR(a)  (Stack + (Regs[63]-(a))) 
 #define GETSTR(ht)      (getStringSafe(ht))
-//#define GETSTR(ht) ((ht) == 0 ? NULL : ( ht < 0 ? SRegs[max(0,-ht)] :       \
+//#define GETSTR(ht) ((ht) == 0 ? NULL : ( ht < 0 ? SRegs[std::max(0,-ht)] :       \
 //                               (theGame->Modules[mn]->QTextSeg + (ht))))
 #endif
 */
@@ -454,8 +454,8 @@ int32 VMachine::Execute(EventInfo *e, rID _xID, hCode CP)
           case INC: *LValue1(vc) += Value2(vc); break;
           case DEC: *LValue1(vc) -= Value2(vc); break;
           case ROLL: REGS(0) = Dice::Roll((int8)Value1(vc),(int8)Value2(vc)); break;
-          case MIN:  REGS(0) = min(Value1(vc),Value2(vc)); break;
-          case MAX:  REGS(0) = max(Value1(vc),Value2(vc)); break;
+          case MIN:  REGS(0) = std::min(Value1(vc),Value2(vc)); break;
+          case MAX:  REGS(0) = std::max(Value1(vc),Value2(vc)); break;
           case MOV: *LValue1(vc) = Value2(vc);         break;
           case BSHL: REGS(0) = Value1(vc) >> Value2(vc); break;
           case BSHR: REGS(0) = Value1(vc) << Value2(vc); break;

--- a/src/Values.cpp
+++ b/src/Values.cpp
@@ -135,7 +135,7 @@ void Creature::AddBonus(int8 btype,int8 attr,int16 bonus) {
     // The problem here is that adding the positive bonus just takes the
     // max, so max(3,-3) = 3 instead of foo(3,-3) = 0. 
     // Thus:
-#define WESMAX(attr,bonus) ((attr < 0) ? attr + bonus : max(attr,bonus))
+#define WESMAX(attr,bonus) ((attr < 0) ? attr + bonus : max<int>(attr,bonus))
     // This doesn't completely fix it, because
     //  Spell1 = -4 STR
     //  Spell2 = +3 STR
@@ -405,19 +405,19 @@ Restart:
         tsav = MonGoodSaves((int8)TMON(mID)->MType[0]) | MonGoodSaves((int8)TMON(mID)->MType[1]) | MonGoodSaves((int8)TMON(mID)->MType[2]);
 
         if (tsav & XBIT(FORT))
-            AddBonus(BONUS_BASE,A_SAV_FORT, GoodSave[max(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_FORT, GoodSave[max<int>(ChallengeRating(),0)]);
         else 
-            AddBonus(BONUS_BASE,A_SAV_FORT, PoorSave[max(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_FORT, PoorSave[max<int>(ChallengeRating(),0)]);
 
         if (tsav & XBIT(REF))
-            AddBonus(BONUS_BASE,A_SAV_REF, GoodSave[max(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_REF, GoodSave[max<int>(ChallengeRating(),0)]);
         else 
-            AddBonus(BONUS_BASE,A_SAV_REF, PoorSave[max(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_REF, PoorSave[max<int>(ChallengeRating(),0)]);
 
         if (tsav & XBIT(WILL))
-            AddBonus(BONUS_BASE,A_SAV_WILL, GoodSave[max(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_WILL, GoodSave[max<int>(ChallengeRating(),0)]);
         else 
-            AddBonus(BONUS_BASE,A_SAV_WILL, PoorSave[max(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_WILL, PoorSave[max<int>(ChallengeRating(),0)]);
 
         // mMana = TMON(mID)->Mana;
     }
@@ -443,7 +443,7 @@ Restart:
                 { AddBonus(BONUS_BASE+i,A_FAT,amt); }
             } 
     } else {
-        int amt = max( ChallengeRating(), 0) / 2; 
+        int amt = max<int>( ChallengeRating(), 0) / 2;
         AddBonus(BONUS_BASE,A_FAT,amt); 
     } 
 
@@ -863,7 +863,7 @@ Restart:
         // deflection bonus equal to its Charisma bonus (always at least +1,
         // even if the creature's Charisma score does not normally provide a
         // bonus).
-        StackBonus(BONUS_CIRC,A_DEF, max(1,Mod2(A_CHA)));
+        StackBonus(BONUS_CIRC,A_DEF, max<int>(1,Mod2(A_CHA)));
     } 
 
     switch (Encumbrance()) {
@@ -1029,7 +1029,7 @@ Restart:
         AddBonus(BONUS_ATTR,A_HIT_OFFHAND,XMod(A_STR));
 
     if (HasFeat(FT_WEAPON_FINESSE))
-        AddBonus(BONUS_ATTR,A_DMG_BRAWL,max(0,XMod(A_STR)));
+        AddBonus(BONUS_ATTR,A_DMG_BRAWL,max<int>(0,XMod(A_STR)));
     else
         AddBonus(BONUS_ATTR,A_DMG_BRAWL,XMod(A_STR));
 
@@ -1045,7 +1045,7 @@ Restart:
         AddBonus(BONUS_ATTR,A_DMG_MELEE,XMod(A_STR));
 
     /* Figure out WT_NO_STRENGTH at attack time */
-    AddBonus(BONUS_ATTR,A_DMG_THROWN,max(0,XMod(A_STR)));
+    AddBonus(BONUS_ATTR,A_DMG_THROWN,max<int>(0,XMod(A_STR)));
     if (missileWep && missileWep->useStrength())
         AddBonus(BONUS_ATTR,A_DMG_ARCHERY,XMod(A_STR));
 
@@ -1070,7 +1070,7 @@ Restart:
         }
 
     if (HasFeat(FT_LIGHTNING_FISTS)) //  && !HasStati(POLYMORPH))
-        AddBonus(BONUS_FEAT,A_SPD_BRAWL,max(0,XMod(A_DEX)));
+        AddBonus(BONUS_FEAT,A_SPD_BRAWL,max<int>(0,XMod(A_DEX)));
     if (HasFeat(FT_FISTS_OF_IRON)) 
         AddBonus(BONUS_FEAT,A_DMG_BRAWL,1); 
 
@@ -1236,9 +1236,9 @@ Restart:
 
     if (HasStati(POLYMORPH))
         for (i=A_STR; i<=A_CON; i++) {
-            AttrAdj[i][BONUS_ENHANCE] = min(0,AttrAdj[i][BONUS_ENHANCE]);
-            AttrAdj[i][BONUS_FEAT] = min(0,AttrAdj[i][BONUS_FEAT]);
-            AttrAdj[i][BONUS_INHERANT] = min(0,AttrAdj[i][BONUS_INHERANT]);
+            AttrAdj[i][BONUS_ENHANCE] = min<int>(0,AttrAdj[i][BONUS_ENHANCE]);
+            AttrAdj[i][BONUS_FEAT] = min<int>(0,AttrAdj[i][BONUS_FEAT]);
+            AttrAdj[i][BONUS_INHERANT] = min<int>(0,AttrAdj[i][BONUS_INHERANT]);
         }
 
     if (HasFeat(FT_LION_HEART)) {
@@ -1275,7 +1275,7 @@ Restart:
             if (percent_attr(i)) {
                 for (j=0;j!=BONUS_LAST;j++)
                     if (bonus_is_mult(i,j)) {
-                        thisc->KAttr[i] = ((((thisc->KAttr[i]*5 + 100) * (max(-16,AttrAdj[i][j])*5 + 100) ) / 100)-100)/5;          
+                        thisc->KAttr[i] = ((((thisc->KAttr[i]*5 + 100) * (max<int>(-16,AttrAdj[i][j])*5 + 100) ) / 100)-100)/5;
 
                         if (i == A_MOV && AttrAdj[i][j] <= -20 && !isPlayer())
                             isHalted = true;
@@ -1283,7 +1283,7 @@ Restart:
             }
 
             thisc->KAttr[A_CDEF] = thisc->KAttr[A_DEF] - 
-                (max(0,AttrAdj[A_DEF][BONUS_WEAPON]) + max(0,AttrAdj[A_DEF][BONUS_INSIGHT]) + max(0,AttrAdj[A_DEF][BONUS_DODGE]) + (HasFeat(FT_COMBAT_CASTING) ? 2 : 4));
+                (max<int>(0,AttrAdj[A_DEF][BONUS_WEAPON]) + max<int>(0,AttrAdj[A_DEF][BONUS_INSIGHT]) + max<int>(0,AttrAdj[A_DEF][BONUS_DODGE]) + (HasFeat(FT_COMBAT_CASTING) ? 2 : 4));
         } 
     } else {
         for(i=0; i!=ATTR_LAST; i++) {
@@ -1317,7 +1317,7 @@ Restart:
             }
 
             Attr[A_CDEF] = Attr[A_DEF] -
-                (max(0,AttrAdj[A_DEF][BONUS_WEAPON]) + max(0,AttrAdj[A_DEF][BONUS_INSIGHT]) + max(0,AttrAdj[A_DEF][BONUS_DODGE]) + (HasFeat(FT_COMBAT_CASTING) ? 2 : 4));
+                (max<int>(0,AttrAdj[A_DEF][BONUS_WEAPON]) + max<int>(0,AttrAdj[A_DEF][BONUS_INSIGHT]) + max<int>(0,AttrAdj[A_DEF][BONUS_DODGE]) + (HasFeat(FT_COMBAT_CASTING) ? 2 : 4));
         }
     }
 
@@ -1349,14 +1349,14 @@ Restart:
             thisp->KAttr[A_FAT] = 1;
 
         if (!isHalted)
-            thisp->KAttr[A_MOV]       = max(min(-15,TMON(mID)->Mov),thisp->KAttr[A_MOV]);
+            thisp->KAttr[A_MOV]       = max<int>(min<int>(-15,TMON(mID)->Mov),thisp->KAttr[A_MOV]);
         else
             thisp->KAttr[A_MOV]       = -20;
-        thisp->KAttr[A_SPD_MELEE]   = max(-15,thisp->KAttr[A_SPD_MELEE]);
-        thisp->KAttr[A_SPD_BRAWL]   = max(-15,thisp->KAttr[A_SPD_BRAWL]);
-        thisp->KAttr[A_SPD_ARCHERY] = max(-15,thisp->KAttr[A_SPD_ARCHERY]);
-        thisp->KAttr[A_SPD_THROWN]  = max(-15,thisp->KAttr[A_SPD_THROWN]);
-        thisp->KAttr[A_SPD_OFFHAND] = max(-15,thisp->KAttr[A_SPD_OFFHAND]);
+        thisp->KAttr[A_SPD_MELEE]   = max<int>(-15,thisp->KAttr[A_SPD_MELEE]);
+        thisp->KAttr[A_SPD_BRAWL]   = max<int>(-15,thisp->KAttr[A_SPD_BRAWL]);
+        thisp->KAttr[A_SPD_ARCHERY] = max<int>(-15,thisp->KAttr[A_SPD_ARCHERY]);
+        thisp->KAttr[A_SPD_THROWN]  = max<int>(-15,thisp->KAttr[A_SPD_THROWN]);
+        thisp->KAttr[A_SPD_OFFHAND] = max<int>(-15,thisp->KAttr[A_SPD_OFFHAND]);
     } else {
         /* If you do not naturally have an attribute of 0, and are not about
         to die as a result of having that attribute at 0, set it to a minimum
@@ -1374,14 +1374,14 @@ Restart:
             Attr[A_FAT] = 1;
 
         if (!isHalted)
-            thisp->Attr[A_MOV]       = max(min(-15,TMON(mID)->Mov),thisp->Attr[A_MOV]);
+            thisp->Attr[A_MOV]       = max<int>(min<int>(-15,TMON(mID)->Mov),thisp->Attr[A_MOV]);
         else
             thisp->Attr[A_MOV]       = -20;
-        thisp->Attr[A_SPD_MELEE]   = max(-15,thisp->Attr[A_SPD_MELEE]);
-        thisp->Attr[A_SPD_BRAWL]   = max(-15,thisp->Attr[A_SPD_BRAWL]);
-        thisp->Attr[A_SPD_ARCHERY] = max(-15,thisp->Attr[A_SPD_ARCHERY]);
-        thisp->Attr[A_SPD_THROWN]  = max(-15,thisp->Attr[A_SPD_THROWN]);
-        thisp->Attr[A_SPD_OFFHAND] = max(-15,thisp->Attr[A_SPD_OFFHAND]);
+        thisp->Attr[A_SPD_MELEE]   = max<int>(-15,thisp->Attr[A_SPD_MELEE]);
+        thisp->Attr[A_SPD_BRAWL]   = max<int>(-15,thisp->Attr[A_SPD_BRAWL]);
+        thisp->Attr[A_SPD_ARCHERY] = max<int>(-15,thisp->Attr[A_SPD_ARCHERY]);
+        thisp->Attr[A_SPD_THROWN]  = max<int>(-15,thisp->Attr[A_SPD_THROWN]);
+        thisp->Attr[A_SPD_OFFHAND] = max<int>(-15,thisp->Attr[A_SPD_OFFHAND]);
 
         Creature *lead;
         if ((lead = getLeader()) && !isHalted)
@@ -1393,9 +1393,9 @@ Restart:
 
         LightRange = EInSlot(SL_LIGHT) ? EInSlot(SL_LIGHT)->GetLightRange() : 0;
         if (InSlot(SL_WEAPON) && InSlot(SL_WEAPON)->HasQuality(WQ_GLOWING))
-            LightRange = max(LightRange,InSlot(SL_WEAPON)->GetPlus()*3);
+            LightRange = max<int>(LightRange,InSlot(SL_WEAPON)->GetPlus()*3);
         if (InSlot(SL_READY) && InSlot(SL_READY)->HasQuality(WQ_GLOWING))
-            LightRange = max(LightRange,InSlot(SL_READY)->GetPlus()*3);
+            LightRange = max<int>(LightRange,InSlot(SL_READY)->GetPlus()*3);
         if (LightRange)
             LightRange += AbilityLevel(CA_LOWLIGHT);
 
@@ -1437,7 +1437,7 @@ Restart:
                         BlindRange -= pen; 
                 }
             }
-            BlindRange = max(1,BlindRange);
+            BlindRange = max<int>(1,BlindRange);
         }
         NatureSight  = HasAbility(CA_NATURE_SENSE);
         PercepRange  = (uint8)HighStatiMag(PERCEPTION);
@@ -1445,7 +1445,7 @@ Restart:
         that they can exist in the dungeon as effective companions to
         druids and rangers. */
         if (!isPlayer() && InfraRange + LightRange + TelepRange + TremorRange + BlindRange + ScentRange == 0)
-            InfraRange = max(6,InfraRange);
+            InfraRange = max<int>(6,InfraRange);
     }
 
     if (Attr[A_FAT] != oFP) {
@@ -1463,7 +1463,7 @@ Restart:
     enough to put them equal to or lower than the new maximum
     hit points. */       
     if (oHP > cHP)
-        cHP = min (mHP+Attr[A_THP], oHP);
+        cHP = min<int>(mHP+Attr[A_THP], oHP);
 
     SetImage();
     if (m && x != -1)
@@ -1630,7 +1630,7 @@ void Character::CalcValues(bool KnownOnly, Item *thrown)
 
 
   if (HasAbility(CA_TOUGH_AS_HELL))
-    mHP += AbilityLevel(CA_TOUGH_AS_HELL) * max(0,Mod(a_hp));
+    mHP += AbilityLevel(CA_TOUGH_AS_HELL) * max<int>(0,Mod(a_hp));
   if (HasFeat(FT_TOUGHNESS))
     mHP += (mHP / 4);
 
@@ -1717,8 +1717,8 @@ void Character::CalcValues(bool KnownOnly, Item *thrown)
     
     /* Scale slots for spell levels 2-9 */
     for (i=1;i<9;i++) { 
-      BonusSlots[i] = min( BonusSpells[intScaled][i] ,
-                               max( SpellSlots[i] ,
+      BonusSlots[i] = min<int>( BonusSpells[intScaled][i] ,
+                               max<int>( SpellSlots[i] ,
                                CasterLev() - SAL(i+1) ) ) ; 
 
       // back to auto-learning domain spells.
@@ -1800,7 +1800,7 @@ int16 Creature::ResistLevel(int16 DType, bool bypass_armour)
       if (!S->Dis)
           if (S->Val == DType)
             StatiResists[S->Source] = 
-              max(StatiResists[S->Source],S->Mag);
+              max<int>(StatiResists[S->Source],S->Mag);
     StatiIterEnd(this)
     
     for(i=0;i!=16;i++)
@@ -1837,7 +1837,7 @@ int16 Creature::ResistLevel(int16 DType, bool bypass_armour)
     
     if (is_wepdmg(DType)) {
       if (Attr[A_ARM] && !bypass_armour)
-        Resists[ResistCount++] = max(0,Attr[A_ARM]);
+        Resists[ResistCount++] = max<int>(0,Attr[A_ARM]);
       if ((it = EInSlot(SL_ARMOUR)) && !bypass_armour)
         Resists[ResistCount++] = ((Armour *)it)->ArmVal(DType - AD_SLASH);
       }
@@ -2042,7 +2042,7 @@ void Creature::CalcHP()
     case SZ_GARGANTUAN:     mHP = (mHP*16)/10; break;
     case SZ_COLLOSAL:       mHP = (mHP*20)/10; break;
   }
-  mHP = max(1,mHP);
+  mHP = max<int>(1,mHP);
   
   /* Knowledge skills give bonuses to summoned creatures'
      hit points. */
@@ -2577,8 +2577,8 @@ int16 Character::GetBAB(int16 mode)
       if (TCLASS(ClassID[i])->AttkVal[mode] >= 100)
         warriorLevels += Level[i];
       }
-    sBAB = min(TotalLevel(), BAB + 
-      min(warriorLevels,IntStudy[STUDY_BAB]));
+    sBAB = min<int>(TotalLevel(), BAB +
+      min<int>(warriorLevels,IntStudy[STUDY_BAB]));
     return max(BAB,sBAB);
   }
 

--- a/src/Values.cpp
+++ b/src/Values.cpp
@@ -133,9 +133,9 @@ void Creature::AddBonus(int8 btype,int8 attr,int16 bonus) {
     // the results are random. 
     //
     // The problem here is that adding the positive bonus just takes the
-    // max, so max(3,-3) = 3 instead of foo(3,-3) = 0. 
+    // max, so std::max(3,-3) = 3 instead of foo(3,-3) = 0. 
     // Thus:
-#define WESMAX(attr,bonus) ((attr < 0) ? attr + bonus : max<int>(attr,bonus))
+#define WESMAX(attr,bonus) ((attr < 0) ? attr + bonus : std::max<int>(attr,bonus))
     // This doesn't completely fix it, because
     //  Spell1 = -4 STR
     //  Spell2 = +3 STR
@@ -363,11 +363,11 @@ Restart:
             StackBonus(BONUS_BASE+i,A_HIT_THROWN, (TCLASS(thisc->ClassID[i])->AttkVal[S_THROWN] * thisc->Level[i])/100);
             StackBonus(BONUS_BASE+i,A_HIT_OFFHAND, (TCLASS(thisc->ClassID[i])->AttkVal[S_MELEE] * thisc->Level[i])/100);
 
-            StackBonus(BONUS_BASE+i,A_SPD_ARCHERY, max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
-            StackBonus(BONUS_BASE+i,A_SPD_BRAWL, max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
-            StackBonus(BONUS_BASE+i,A_SPD_MELEE, max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
-            StackBonus(BONUS_BASE+i,A_SPD_THROWN, max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
-            StackBonus(BONUS_BASE+i,A_SPD_OFFHAND, max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
+            StackBonus(BONUS_BASE+i,A_SPD_ARCHERY, std::max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
+            StackBonus(BONUS_BASE+i,A_SPD_BRAWL, std::max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
+            StackBonus(BONUS_BASE+i,A_SPD_MELEE, std::max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
+            StackBonus(BONUS_BASE+i,A_SPD_THROWN, std::max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
+            StackBonus(BONUS_BASE+i,A_SPD_OFFHAND, std::max(0,AttrAdj[A_HIT_ARCHERY][BONUS_BASE+i] - (thisc->Level[i]/2)));
 
             StackBonus(BONUS_BASE+i,A_SAV_FORT, TCLASS(thisc->ClassID[i])->HasFlag(CF_GOOD_FORT) ? GoodSave[thisc->Level[i]] : PoorSave[thisc->Level[i]]);
             StackBonus(BONUS_BASE+i,A_SAV_REF, TCLASS(thisc->ClassID[i])->HasFlag(CF_GOOD_REF) ? GoodSave[thisc->Level[i]] : PoorSave[thisc->Level[i]]);
@@ -395,7 +395,7 @@ Restart:
                 AddBonus(BONUS_BASE,i,TMON(mID)->Attr[i]);
         } else {
             for (i = 0; i != 7; i++) 
-                AddBonus(BONUS_BASE,i,max(TMON(tmID)->Attr[i],TMON(mID)->Attr[i]));
+                AddBonus(BONUS_BASE,i, std::max(TMON(tmID)->Attr[i],TMON(mID)->Attr[i]));
         }
 
         AddBonus(BONUS_BASE,A_HIT,TMON(mID)->Hit);
@@ -405,19 +405,19 @@ Restart:
         tsav = MonGoodSaves((int8)TMON(mID)->MType[0]) | MonGoodSaves((int8)TMON(mID)->MType[1]) | MonGoodSaves((int8)TMON(mID)->MType[2]);
 
         if (tsav & XBIT(FORT))
-            AddBonus(BONUS_BASE,A_SAV_FORT, GoodSave[max<int>(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_FORT, GoodSave[std::max<int>(ChallengeRating(),0)]);
         else 
-            AddBonus(BONUS_BASE,A_SAV_FORT, PoorSave[max<int>(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_FORT, PoorSave[std::max<int>(ChallengeRating(),0)]);
 
         if (tsav & XBIT(REF))
-            AddBonus(BONUS_BASE,A_SAV_REF, GoodSave[max<int>(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_REF, GoodSave[std::max<int>(ChallengeRating(),0)]);
         else 
-            AddBonus(BONUS_BASE,A_SAV_REF, PoorSave[max<int>(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_REF, PoorSave[std::max<int>(ChallengeRating(),0)]);
 
         if (tsav & XBIT(WILL))
-            AddBonus(BONUS_BASE,A_SAV_WILL, GoodSave[max<int>(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_WILL, GoodSave[std::max<int>(ChallengeRating(),0)]);
         else 
-            AddBonus(BONUS_BASE,A_SAV_WILL, PoorSave[max<int>(ChallengeRating(),0)]);
+            AddBonus(BONUS_BASE,A_SAV_WILL, PoorSave[std::max<int>(ChallengeRating(),0)]);
 
         // mMana = TMON(mID)->Mana;
     }
@@ -443,7 +443,7 @@ Restart:
                 { AddBonus(BONUS_BASE+i,A_FAT,amt); }
             } 
     } else {
-        int amt = max<int>( ChallengeRating(), 0) / 2;
+        int amt = std::max<int>( ChallengeRating(), 0) / 2;
         AddBonus(BONUS_BASE,A_FAT,amt); 
     } 
 
@@ -693,13 +693,13 @@ Restart:
 		int16 n_add = 0, n_div = 1;
         // Concentration cancels pain as does Pain Tolerance
 		if (HasSkill(SK_CONCENT))
-			n_add = max(((SkillLevel(SK_CONCENT) - 8) / 2), 0);
+			n_add = std::max(((SkillLevel(SK_CONCENT) - 8) / 2), 0);
         if (this->HasFeat(FT_PAIN_TOLERANCE))
             n_div = 2;
 		if (n_add > 0 || n_div != 1)
 			for (i = 0; i != ATTR_LAST; i++)
 				if (AttrAdj[i][BONUS_PAIN] < 0) {
-					AttrAdj[i][BONUS_PAIN] = min(0, AttrAdj[i][BONUS_PAIN] + n_add);
+					AttrAdj[i][BONUS_PAIN] = std::min(0, AttrAdj[i][BONUS_PAIN] + n_add);
 					AttrAdj[i][BONUS_PAIN] = AttrAdj[i][BONUS_PAIN] / n_div;
 				}
     }
@@ -789,7 +789,7 @@ Restart:
         AddBonus(BONUS_ELEV,A_DEF,SkillLevel(SK_CLIMB)/6+2);
         AddBonus(BONUS_ELEV,A_HIT,SkillLevel(SK_CLIMB)/6+2);
         if (GetStatiVal(ELEVATED) == ELEV_CEILING)
-            AddBonus(BONUS_ELEV,A_MOV, -14 + max(0,SkillLevel(SK_CLIMB)-20));
+            AddBonus(BONUS_ELEV,A_MOV, -14 + std::max(0,SkillLevel(SK_CLIMB)-20));
         else if (HasFeat(FT_BRACHIATION))
             ;
         else
@@ -863,7 +863,7 @@ Restart:
         // deflection bonus equal to its Charisma bonus (always at least +1,
         // even if the creature's Charisma score does not normally provide a
         // bonus).
-        StackBonus(BONUS_CIRC,A_DEF, max<int>(1,Mod2(A_CHA)));
+        StackBonus(BONUS_CIRC,A_DEF, std::max<int>(1,Mod2(A_CHA)));
     } 
 
     switch (Encumbrance()) {
@@ -947,8 +947,8 @@ Restart:
     }
 
     if (HasSkill(SK_ATHLETICS)) {
-        AddBonus(BONUS_SKILL, A_MOV, max(0,SkillLevel(SK_ATHLETICS)/2)); 
-        AddBonus(BONUS_SKILL,A_FAT,max(0,SkillLevel(SK_ATHLETICS)/3));
+        AddBonus(BONUS_SKILL, A_MOV, std::max(0,SkillLevel(SK_ATHLETICS)/2));
+        AddBonus(BONUS_SKILL,A_FAT, std::max(0,SkillLevel(SK_ATHLETICS)/3));
     }
 
     if (isMType(MA_UNDEAD) || isMType(MA_CONSTRUCT) || isMType(MA_PLANT)) {
@@ -998,8 +998,8 @@ Restart:
         Attr[A_FAT] = 1;
 
     if (HasFeat(FT_ONE_BODY_ONE_SOUL) || (Attr[A_CON] == 0)) {
-        int16 one_mod = max(XMod(A_CON),XMod(A_WIS));
-        int16 best = max(IAttr(A_CON),IAttr(A_WIS));
+        int16 one_mod = std::max(XMod(A_CON),XMod(A_WIS));
+        int16 best = std::max(IAttr(A_CON),IAttr(A_WIS));
         AddBonus(BONUS_ATTR,A_SAV_FORT, one_mod);
         AddBonus(BONUS_ATTR,A_SAV_WILL, one_mod);
         AddBonus(BONUS_ATTR,A_FAT,(best-11)/2); 
@@ -1014,22 +1014,22 @@ Restart:
     AddBonus(BONUS_ATTR,A_HIT_THROWN,  XMod(A_DEX));
 
     if (HasFeat(FT_WEAPON_FINESSE))
-        AddBonus(BONUS_ATTR,A_HIT_BRAWL,max(XMod(A_STR),XMod(A_DEX)));
+        AddBonus(BONUS_ATTR,A_HIT_BRAWL, std::max(XMod(A_STR),XMod(A_DEX)));
     else
         AddBonus(BONUS_ATTR,A_HIT_BRAWL,XMod(A_STR));
 
     if (HasFeat(FT_WEAPON_FINESSE) && meleeWep && meleeWep->canFinesse()) 
-        AddBonus(BONUS_ATTR,A_HIT_MELEE,max(XMod(A_STR),XMod(A_DEX))); 
+        AddBonus(BONUS_ATTR,A_HIT_MELEE, std::max(XMod(A_STR),XMod(A_DEX)));
     else
         AddBonus(BONUS_ATTR,A_HIT_MELEE,XMod(A_STR));
 
     if (HasFeat(FT_WEAPON_FINESSE) && offhandWep && offhandWep->canFinesse()) 
-        AddBonus(BONUS_ATTR,A_HIT_OFFHAND,max(XMod(A_STR),XMod(A_DEX)));
+        AddBonus(BONUS_ATTR,A_HIT_OFFHAND, std::max(XMod(A_STR),XMod(A_DEX)));
     else
         AddBonus(BONUS_ATTR,A_HIT_OFFHAND,XMod(A_STR));
 
     if (HasFeat(FT_WEAPON_FINESSE))
-        AddBonus(BONUS_ATTR,A_DMG_BRAWL,max<int>(0,XMod(A_STR)));
+        AddBonus(BONUS_ATTR,A_DMG_BRAWL, std::max<int>(0,XMod(A_STR)));
     else
         AddBonus(BONUS_ATTR,A_DMG_BRAWL,XMod(A_STR));
 
@@ -1040,12 +1040,12 @@ Restart:
     if (meleeWep && !meleeWep->useStrength())
         ;
     else if (meleeWep && (EInSlot(SL_WEAPON) == EInSlot(SL_READY)) && !meleeWep->HasIFlag(WT_DOUBLE))      
-        AddBonus(BONUS_ATTR,A_DMG_MELEE,max(0,((XMod(A_STR)*3)+1)/2));
+        AddBonus(BONUS_ATTR,A_DMG_MELEE, std::max(0,((XMod(A_STR)*3)+1)/2));
     else if (XMod(A_STR) >= 0 || !HasFeat(FT_WEAPON_FINESSE) || (meleeWep && !meleeWep->canFinesse()))
         AddBonus(BONUS_ATTR,A_DMG_MELEE,XMod(A_STR));
 
     /* Figure out WT_NO_STRENGTH at attack time */
-    AddBonus(BONUS_ATTR,A_DMG_THROWN,max<int>(0,XMod(A_STR)));
+    AddBonus(BONUS_ATTR,A_DMG_THROWN, std::max<int>(0,XMod(A_STR)));
     if (missileWep && missileWep->useStrength())
         AddBonus(BONUS_ATTR,A_DMG_ARCHERY,XMod(A_STR));
 
@@ -1070,7 +1070,7 @@ Restart:
         }
 
     if (HasFeat(FT_LIGHTNING_FISTS)) //  && !HasStati(POLYMORPH))
-        AddBonus(BONUS_FEAT,A_SPD_BRAWL,max<int>(0,XMod(A_DEX)));
+        AddBonus(BONUS_FEAT,A_SPD_BRAWL, std::max<int>(0,XMod(A_DEX)));
     if (HasFeat(FT_FISTS_OF_IRON)) 
         AddBonus(BONUS_FEAT,A_DMG_BRAWL,1); 
 
@@ -1113,9 +1113,9 @@ Restart:
 
         // ww: this logic was reversed! ouch!
         if (!HasFeat(FT_DEFENSIVE_SYNERGY))
-            AddBonus(BONUS_WEAPON,A_DEF,max(a,b));
+            AddBonus(BONUS_WEAPON,A_DEF, std::max(a,b));
         else
-            AddBonus(BONUS_WEAPON,A_DEF,max(a,b) + min(a,b)/2);
+            AddBonus(BONUS_WEAPON,A_DEF, std::max(a,b) + std::min(a,b)/2);
     } 
 
     if (meleeWep && meleeWep->HasQuality(WQ_DEFENDING))
@@ -1148,7 +1148,7 @@ Restart:
         AddBonus(BONUS_GRACE, A_SAV, XMod(A_CHA));
 
     if (isMType(MA_CHAOTIC) && isCharacter())
-        AddBonus(BONUS_MORALE, A_SAV_WILL, max(0,(thisc->alignLC - 35) / 5));
+        AddBonus(BONUS_MORALE, A_SAV_WILL, std::max(0,(thisc->alignLC - 35) / 5));
     else if (isMType(MA_CHAOTIC))
         AddBonus(BONUS_MORALE, A_SAV_WILL, HasMFlag(M_IALIGN) ? 6 : 3);
 
@@ -1207,7 +1207,7 @@ Restart:
         { AddBonus(BONUS_WEAPON, A_DEF, TITEM(offhandWep->iID)->Def +
         TITEM(meleeWep->iID)->Def) }
         else
-        {AddBonus(BONUS_WEAPON, A_DEF, max(TITEM(offhandWep->iID)->Def,
+        {AddBonus(BONUS_WEAPON, A_DEF, std::max(TITEM(offhandWep->iID)->Def,
         TITEM(meleeWep->iID)->Def)); }
         */
     }
@@ -1236,9 +1236,9 @@ Restart:
 
     if (HasStati(POLYMORPH))
         for (i=A_STR; i<=A_CON; i++) {
-            AttrAdj[i][BONUS_ENHANCE] = min<int>(0,AttrAdj[i][BONUS_ENHANCE]);
-            AttrAdj[i][BONUS_FEAT] = min<int>(0,AttrAdj[i][BONUS_FEAT]);
-            AttrAdj[i][BONUS_INHERANT] = min<int>(0,AttrAdj[i][BONUS_INHERANT]);
+            AttrAdj[i][BONUS_ENHANCE] = std::min<int>(0,AttrAdj[i][BONUS_ENHANCE]);
+            AttrAdj[i][BONUS_FEAT] = std::min<int>(0,AttrAdj[i][BONUS_FEAT]);
+            AttrAdj[i][BONUS_INHERANT] = std::min<int>(0,AttrAdj[i][BONUS_INHERANT]);
         }
 
     if (HasFeat(FT_LION_HEART)) {
@@ -1275,7 +1275,7 @@ Restart:
             if (percent_attr(i)) {
                 for (j=0;j!=BONUS_LAST;j++)
                     if (bonus_is_mult(i,j)) {
-                        thisc->KAttr[i] = ((((thisc->KAttr[i]*5 + 100) * (max<int>(-16,AttrAdj[i][j])*5 + 100) ) / 100)-100)/5;
+                        thisc->KAttr[i] = ((((thisc->KAttr[i]*5 + 100) * (std::max<int>(-16,AttrAdj[i][j])*5 + 100) ) / 100)-100)/5;
 
                         if (i == A_MOV && AttrAdj[i][j] <= -20 && !isPlayer())
                             isHalted = true;
@@ -1283,7 +1283,7 @@ Restart:
             }
 
             thisc->KAttr[A_CDEF] = thisc->KAttr[A_DEF] - 
-                (max<int>(0,AttrAdj[A_DEF][BONUS_WEAPON]) + max<int>(0,AttrAdj[A_DEF][BONUS_INSIGHT]) + max<int>(0,AttrAdj[A_DEF][BONUS_DODGE]) + (HasFeat(FT_COMBAT_CASTING) ? 2 : 4));
+                (std::max<int>(0,AttrAdj[A_DEF][BONUS_WEAPON]) + std::max<int>(0,AttrAdj[A_DEF][BONUS_INSIGHT]) + std::max<int>(0,AttrAdj[A_DEF][BONUS_DODGE]) + (HasFeat(FT_COMBAT_CASTING) ? 2 : 4));
         } 
     } else {
         for(i=0; i!=ATTR_LAST; i++) {
@@ -1317,7 +1317,7 @@ Restart:
             }
 
             Attr[A_CDEF] = Attr[A_DEF] -
-                (max<int>(0,AttrAdj[A_DEF][BONUS_WEAPON]) + max<int>(0,AttrAdj[A_DEF][BONUS_INSIGHT]) + max<int>(0,AttrAdj[A_DEF][BONUS_DODGE]) + (HasFeat(FT_COMBAT_CASTING) ? 2 : 4));
+                (std::max<int>(0,AttrAdj[A_DEF][BONUS_WEAPON]) + std::max<int>(0,AttrAdj[A_DEF][BONUS_INSIGHT]) + std::max<int>(0,AttrAdj[A_DEF][BONUS_DODGE]) + (HasFeat(FT_COMBAT_CASTING) ? 2 : 4));
         }
     }
 
@@ -1349,14 +1349,14 @@ Restart:
             thisp->KAttr[A_FAT] = 1;
 
         if (!isHalted)
-            thisp->KAttr[A_MOV]       = max<int>(min<int>(-15,TMON(mID)->Mov),thisp->KAttr[A_MOV]);
+            thisp->KAttr[A_MOV]       = std::max<int>(std::min<int>(-15,TMON(mID)->Mov),thisp->KAttr[A_MOV]);
         else
             thisp->KAttr[A_MOV]       = -20;
-        thisp->KAttr[A_SPD_MELEE]   = max<int>(-15,thisp->KAttr[A_SPD_MELEE]);
-        thisp->KAttr[A_SPD_BRAWL]   = max<int>(-15,thisp->KAttr[A_SPD_BRAWL]);
-        thisp->KAttr[A_SPD_ARCHERY] = max<int>(-15,thisp->KAttr[A_SPD_ARCHERY]);
-        thisp->KAttr[A_SPD_THROWN]  = max<int>(-15,thisp->KAttr[A_SPD_THROWN]);
-        thisp->KAttr[A_SPD_OFFHAND] = max<int>(-15,thisp->KAttr[A_SPD_OFFHAND]);
+        thisp->KAttr[A_SPD_MELEE]   = std::max<int>(-15,thisp->KAttr[A_SPD_MELEE]);
+        thisp->KAttr[A_SPD_BRAWL]   = std::max<int>(-15,thisp->KAttr[A_SPD_BRAWL]);
+        thisp->KAttr[A_SPD_ARCHERY] = std::max<int>(-15,thisp->KAttr[A_SPD_ARCHERY]);
+        thisp->KAttr[A_SPD_THROWN]  = std::max<int>(-15,thisp->KAttr[A_SPD_THROWN]);
+        thisp->KAttr[A_SPD_OFFHAND] = std::max<int>(-15,thisp->KAttr[A_SPD_OFFHAND]);
     } else {
         /* If you do not naturally have an attribute of 0, and are not about
         to die as a result of having that attribute at 0, set it to a minimum
@@ -1374,14 +1374,14 @@ Restart:
             Attr[A_FAT] = 1;
 
         if (!isHalted)
-            thisp->Attr[A_MOV]       = max<int>(min<int>(-15,TMON(mID)->Mov),thisp->Attr[A_MOV]);
+            thisp->Attr[A_MOV]       = std::max<int>(std::min<int>(-15,TMON(mID)->Mov),thisp->Attr[A_MOV]);
         else
             thisp->Attr[A_MOV]       = -20;
-        thisp->Attr[A_SPD_MELEE]   = max<int>(-15,thisp->Attr[A_SPD_MELEE]);
-        thisp->Attr[A_SPD_BRAWL]   = max<int>(-15,thisp->Attr[A_SPD_BRAWL]);
-        thisp->Attr[A_SPD_ARCHERY] = max<int>(-15,thisp->Attr[A_SPD_ARCHERY]);
-        thisp->Attr[A_SPD_THROWN]  = max<int>(-15,thisp->Attr[A_SPD_THROWN]);
-        thisp->Attr[A_SPD_OFFHAND] = max<int>(-15,thisp->Attr[A_SPD_OFFHAND]);
+        thisp->Attr[A_SPD_MELEE]   = std::max<int>(-15,thisp->Attr[A_SPD_MELEE]);
+        thisp->Attr[A_SPD_BRAWL]   = std::max<int>(-15,thisp->Attr[A_SPD_BRAWL]);
+        thisp->Attr[A_SPD_ARCHERY] = std::max<int>(-15,thisp->Attr[A_SPD_ARCHERY]);
+        thisp->Attr[A_SPD_THROWN]  = std::max<int>(-15,thisp->Attr[A_SPD_THROWN]);
+        thisp->Attr[A_SPD_OFFHAND] = std::max<int>(-15,thisp->Attr[A_SPD_OFFHAND]);
 
         Creature *lead;
         if ((lead = getLeader()) && !isHalted)
@@ -1389,13 +1389,13 @@ Restart:
                 if (lead->HasFeat(FT_COORDINATED_TACTICS))
                     Attr[A_MOV] = lead->GetAttr(A_MOV);
 
-        SightRange = max(12,15+Mod(A_WIS)*3) + AbilityLevel(CA_SHARP_SENSES)*2;
+        SightRange = std::max(12,15+Mod(A_WIS)*3) + AbilityLevel(CA_SHARP_SENSES)*2;
 
         LightRange = EInSlot(SL_LIGHT) ? EInSlot(SL_LIGHT)->GetLightRange() : 0;
         if (InSlot(SL_WEAPON) && InSlot(SL_WEAPON)->HasQuality(WQ_GLOWING))
-            LightRange = max<int>(LightRange,InSlot(SL_WEAPON)->GetPlus()*3);
+            LightRange = std::max<int>(LightRange,InSlot(SL_WEAPON)->GetPlus()*3);
         if (InSlot(SL_READY) && InSlot(SL_READY)->HasQuality(WQ_GLOWING))
-            LightRange = max<int>(LightRange,InSlot(SL_READY)->GetPlus()*3);
+            LightRange = std::max<int>(LightRange,InSlot(SL_READY)->GetPlus()*3);
         if (LightRange)
             LightRange += AbilityLevel(CA_LOWLIGHT);
 
@@ -1437,7 +1437,7 @@ Restart:
                         BlindRange -= pen; 
                 }
             }
-            BlindRange = max<int>(1,BlindRange);
+            BlindRange = std::max<int>(1,BlindRange);
         }
         NatureSight  = HasAbility(CA_NATURE_SENSE);
         PercepRange  = (uint8)HighStatiMag(PERCEPTION);
@@ -1445,14 +1445,14 @@ Restart:
         that they can exist in the dungeon as effective companions to
         druids and rangers. */
         if (!isPlayer() && InfraRange + LightRange + TelepRange + TremorRange + BlindRange + ScentRange == 0)
-            InfraRange = max<int>(6,InfraRange);
+            InfraRange = std::max<int>(6,InfraRange);
     }
 
     if (Attr[A_FAT] != oFP) {
         if (restart_count++ < 10) 
             goto Restart;
         // ww: you lose! 
-        Attr[A_FAT] = min(Attr[A_FAT],oFP);
+        Attr[A_FAT] = std::min(Attr[A_FAT],oFP);
         // ww: fixme, this is hideous! 
     }
 
@@ -1463,7 +1463,7 @@ Restart:
     enough to put them equal to or lower than the new maximum
     hit points. */       
     if (oHP > cHP)
-        cHP = min<int>(mHP+Attr[A_THP], oHP);
+        cHP = std::min<int>(mHP+Attr[A_THP], oHP);
 
     SetImage();
     if (m && x != -1)
@@ -1597,22 +1597,22 @@ void Character::CalcValues(bool KnownOnly, Item *thrown)
 
     if (templateHD > 0) {
       if (isPlayer() && thisp->Opt(OPT_MAX_HP) == 2) // max hp
-        mHP += templateHD * max(1, Mod(a_hp) + HDType);
+        mHP += templateHD * std::max(1, Mod(a_hp) + HDType);
       else 
-        mHP += templateHD * max(1, Mod(a_hp) + HDType/2);
+        mHP += templateHD * std::max(1, Mod(a_hp) + HDType/2);
     }
 
     if (HDType > 8) {
       if (isPlayer() && thisp->Opt(OPT_MAX_HP) == 2) // max hp
-        mHP += lev * max(1, Mod(a_hp) + HDType);
+        mHP += lev * std::max(1, Mod(a_hp) + HDType);
       else 
-        mHP += lev * max(1, Mod(a_hp) + HDType/2);
+        mHP += lev * std::max(1, Mod(a_hp) + HDType/2);
     } else {
       for (i=0;i!=3;i++)
         if (Level[i])
         {
           for (j=0;j!=Level[i];j++)
-            mHP += max(1,Mod(a_hp) + thisp->hpRolls[i][j]);
+            mHP += std::max(1,Mod(a_hp) + thisp->hpRolls[i][j]);
         }
     } 
   } else {
@@ -1623,14 +1623,14 @@ void Character::CalcValues(bool KnownOnly, Item *thrown)
 
     // sadly, we can't really "roll" here 
     if (isPlayer() && thisp->Opt(OPT_MAX_HP) == 2) // max hp
-      mHP += numHD * max(1, Mod(a_hp) + HDType);
+      mHP += numHD * std::max(1, Mod(a_hp) + HDType);
     else 
-      mHP += numHD * max(1, Mod(a_hp) + HDType/2);
+      mHP += numHD * std::max(1, Mod(a_hp) + HDType/2);
   } 
 
 
   if (HasAbility(CA_TOUGH_AS_HELL))
-    mHP += AbilityLevel(CA_TOUGH_AS_HELL) * max<int>(0,Mod(a_hp));
+    mHP += AbilityLevel(CA_TOUGH_AS_HELL) * std::max<int>(0,Mod(a_hp));
   if (HasFeat(FT_TOUGHNESS))
     mHP += (mHP / 4);
 
@@ -1685,7 +1685,7 @@ void Character::CalcValues(bool KnownOnly, Item *thrown)
   // ww: calculate bonus spell slots ... this used to be in GainAbility,
   // but players can get frustrated if they read a Tome of Super Int +2 and
   // don't immediately get those bonus spells!
-  uint8 intScaled = min(max(IAttr(A_INT)-9,0),21);
+  uint8 intScaled = std::min(std::max(IAttr(A_INT)-9,0),21);
   // while were here, change the logic a bit (I know, I know ...) so that
   // your maximum number of bonus spells for spell level X is equal to the
   // number of normal spells you could get for level X (unless level 1, at
@@ -1701,7 +1701,7 @@ void Character::CalcValues(bool KnownOnly, Item *thrown)
   // two levels. 
   // fjm: Slight tweak here -- it's very possible to get more bonus spells
   //      at a level than you will ever get of regular spell. Change this
-  //      to bonus slots == max(normal slots, number of levels you've
+  //      to bonus slots == std::max(normal slots, number of levels you've
   //      advanced since first getting access to that specific slot.
   
     for (i=1;i<9;i++)
@@ -1717,8 +1717,8 @@ void Character::CalcValues(bool KnownOnly, Item *thrown)
     
     /* Scale slots for spell levels 2-9 */
     for (i=1;i<9;i++) { 
-      BonusSlots[i] = min<int>( BonusSpells[intScaled][i] ,
-                               max<int>( SpellSlots[i] ,
+      BonusSlots[i] = std::min<int>( BonusSpells[intScaled][i] ,
+                               std::max<int>( SpellSlots[i] ,
                                CasterLev() - SAL(i+1) ) ) ; 
 
       // back to auto-learning domain spells.
@@ -1800,7 +1800,7 @@ int16 Creature::ResistLevel(int16 DType, bool bypass_armour)
       if (!S->Dis)
           if (S->Val == DType)
             StatiResists[S->Source] = 
-              max<int>(StatiResists[S->Source],S->Mag);
+              std::max<int>(StatiResists[S->Source],S->Mag);
     StatiIterEnd(this)
     
     for(i=0;i!=16;i++)
@@ -1837,7 +1837,7 @@ int16 Creature::ResistLevel(int16 DType, bool bypass_armour)
     
     if (is_wepdmg(DType)) {
       if (Attr[A_ARM] && !bypass_armour)
-        Resists[ResistCount++] = max<int>(0,Attr[A_ARM]);
+        Resists[ResistCount++] = std::max<int>(0,Attr[A_ARM]);
       if ((it = EInSlot(SL_ARMOUR)) && !bypass_armour)
         Resists[ResistCount++] = ((Armour *)it)->ArmVal(DType - AD_SLASH);
       }
@@ -2011,7 +2011,7 @@ void Creature::CalcHP()
     HasAbility(CA_SPELLCASTING) ? 12 : 4; 
 
   int effectiveManaLevel = 
-    max(ChallengeRating() ,
+      std::max(ChallengeRating() ,
         AbilityLevel(CA_SPELLCASTING));
 
   for (i=0; i<effectiveManaLevel; i++) {
@@ -2026,7 +2026,7 @@ void Creature::CalcHP()
   if (one_body && Mod(A_WIS) > Mod(A_CON))
     a_hp = A_WIS;
 
-  mHP = max(mHP/2,mHP + (HD * Mod(a_hp)));
+  mHP = std::max(mHP/2,mHP + (HD * Mod(a_hp)));
   if (HasAbility(CA_TOUGH_AS_HELL))
     mHP += Mod(a_hp) * AbilityLevel(CA_TOUGH_AS_HELL);
   if (HasFeat(FT_TOUGHNESS))
@@ -2042,7 +2042,7 @@ void Creature::CalcHP()
     case SZ_GARGANTUAN:     mHP = (mHP*16)/10; break;
     case SZ_COLLOSAL:       mHP = (mHP*20)/10; break;
   }
-  mHP = max<int>(1,mHP);
+  mHP = std::max<int>(1,mHP);
   
   /* Knowledge skills give bonuses to summoned creatures'
      hit points. */
@@ -2073,9 +2073,9 @@ void Character::CalcSP()
       TClass *tc = TCLASS(ClassID[i]);
       if (tc) {
         if (tc->SkillPoints >= 8)
-          TotalSP[i] = max(1, (tc->SkillPoints) + ((IAttr(A_INT)-10)/2)*2);
+          TotalSP[i] = std::max(1, (tc->SkillPoints) + ((IAttr(A_INT)-10)/2)*2);
         else      
-          TotalSP[i] = max(1, (tc->SkillPoints) + ((IAttr(A_INT)-10)/2));
+          TotalSP[i] = std::max(1, (tc->SkillPoints) + ((IAttr(A_INT)-10)/2));
         }
       else
         TotalSP[i] = 0;
@@ -2577,9 +2577,9 @@ int16 Character::GetBAB(int16 mode)
       if (TCLASS(ClassID[i])->AttkVal[mode] >= 100)
         warriorLevels += Level[i];
       }
-    sBAB = min<int>(TotalLevel(), BAB +
-      min<int>(warriorLevels,IntStudy[STUDY_BAB]));
-    return max(BAB,sBAB);
+    sBAB = std::min<int>(TotalLevel(), BAB +
+        std::min<int>(warriorLevels,IntStudy[STUDY_BAB]));
+    return std::max(BAB,sBAB);
   }
 
 uint32 Creature::getArmourType(bool count_shield)

--- a/src/Vision.cpp
+++ b/src/Vision.cpp
@@ -276,18 +276,18 @@ void Map::VisionThing(int16 pn, Creature *c, bool do_clear)
 
   const int16 sx = c->x;
   const int16 sy = c->y; 
-  const int16 LightRange = max(c->LightRange,c->InfraRange);
+  const int16 LightRange = std::max(c->LightRange,c->InfraRange);
   const int16 SightRange = c->SightRange;
-  const int16 ShadowRange = max<int>(c->ShadowRange,LightRange);
+  const int16 ShadowRange = std::max<int>(c->ShadowRange,LightRange);
   const int16 BlindRange = c->BlindRange; 
   const int16 PercepRange = c->PercepRange; 
   const int16 TremorRange = 
-    max<int>(c->TremorRange, c->AbilityLevel(CA_STONEWORK_SENSE));
+      std::max<int>(c->TremorRange, c->AbilityLevel(CA_STONEWORK_SENSE));
 
-  const int16 x1 = max(p->MyTerm->OffsetX()-5,0);
-  const int16 y1 = max(p->MyTerm->OffsetY()-5,0);
-  const int16 x2 = min(x1 + p->MyTerm->MSizeX()+10,sizeX-1);
-  const int16 y2 = min(y1 + p->MyTerm->MSizeY()+10,sizeY-1);
+  const int16 x1 = std::max(p->MyTerm->OffsetX()-5,0);
+  const int16 y1 = std::max(p->MyTerm->OffsetY()-5,0);
+  const int16 x2 = std::min(x1 + p->MyTerm->MSizeX()+10,sizeX-1);
+  const int16 y2 = std::min(y1 + p->MyTerm->MSizeY()+10,sizeY-1);
 
   if (do_clear) 
     for (cx=x1;cx<=x2;cx++)
@@ -491,7 +491,7 @@ uint16 Creature::Perceives(Thing *t, bool assertLOS) {
         ty = t->y;
     }
 
-    const int16 Dist = max<int>(1, dist(x, y, tx, ty));
+    const int16 Dist = std::max<int>(1, dist(x, y, tx, ty));
 
     if (!HasStati_ENGULFED)
         StatiIterNature(this, TRACKING)
@@ -647,7 +647,7 @@ InvisToTremor:;
         return Per;
     }
 
-    if (max(abs(x - tx), abs(y - ty)) > max(SightRange, BlindRange)) {
+    if (std::max(abs(x - tx), abs(y - ty)) > std::max(SightRange, BlindRange)) {
         theGame->inPerceive--;
         return Per;
     }

--- a/src/Vision.cpp
+++ b/src/Vision.cpp
@@ -278,11 +278,11 @@ void Map::VisionThing(int16 pn, Creature *c, bool do_clear)
   const int16 sy = c->y; 
   const int16 LightRange = max(c->LightRange,c->InfraRange);
   const int16 SightRange = c->SightRange;
-  const int16 ShadowRange = max(c->ShadowRange,LightRange); 
+  const int16 ShadowRange = max<int>(c->ShadowRange,LightRange);
   const int16 BlindRange = c->BlindRange; 
   const int16 PercepRange = c->PercepRange; 
   const int16 TremorRange = 
-    max(c->TremorRange, c->AbilityLevel(CA_STONEWORK_SENSE)); 
+    max<int>(c->TremorRange, c->AbilityLevel(CA_STONEWORK_SENSE));
 
   const int16 x1 = max(p->MyTerm->OffsetX()-5,0);
   const int16 y1 = max(p->MyTerm->OffsetY()-5,0);
@@ -491,7 +491,7 @@ uint16 Creature::Perceives(Thing *t, bool assertLOS) {
         ty = t->y;
     }
 
-    const int16 Dist = max(1, dist(x, y, tx, ty));
+    const int16 Dist = max<int>(1, dist(x, y, tx, ty));
 
     if (!HasStati_ENGULFED)
         StatiIterNature(this, TRACKING)

--- a/src/Wcurses.cpp
+++ b/src/Wcurses.cpp
@@ -59,11 +59,14 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 
+// Prevent <windows.h> min/max definitions
+#define NOMINMAX
+
 #undef TRACE
-#undef MIN
-#undef MAX
 #undef ERROR
 #undef EV_BREAK
+
+#include <algorithm>
 
 #include <direct.h>
 #include <stdarg.h>
@@ -81,23 +84,17 @@
 #pragma comment(lib, "crash_generation_client")
 #include "client/windows/handler/exception_handler.h"
 #undef ERROR
-#undef MIN
-#undef MAX
 #undef EV_BREAK
 #endif
 
 #include "Incursion.h"
 #undef ERROR
-#undef MIN
-#undef MAX
 
 #define PDC_WIDE
 #include "curses.h"
 //#define TCOD_NOBASETYPES
 //#include "libtcod.h"
 //#undef ERROR
-//#undef MIN
-//#undef MAX
 
 //#define SDL_MAIN_HANDLED
 //#include "SDL.h"
@@ -935,8 +932,8 @@ RetryFont:
 	}
 
     if (sizeX < 80 || sizeY < 48) {
-		desiredSizeX = max(sizeX, 80);
-		desiredSizeY = max(sizeY, 48);
+		desiredSizeX = std::max<int>(sizeX, 80);
+		desiredSizeY = std::max<int>(sizeY, 48);
 		resize_term(desiredSizeY, desiredSizeX);
 	    goto RetryFont;
     }
@@ -1114,7 +1111,7 @@ void cursesTerm::SClear() {
 }
 
 void cursesTerm::BlitScrollLine(int16 wn, int32 buffline, int32 winline) {
-	size_t copy_width = min(SCROLL_WIDTH, WinSizeX());
+	size_t copy_width = std::min<int>(SCROLL_WIDTH, WinSizeX());
 	int32 src_yindex = buffline * SCROLL_WIDTH;
 
 	for (size_t i = 0; i < copy_width; i++) {

--- a/src/Wlibtcod.cpp
+++ b/src/Wlibtcod.cpp
@@ -58,32 +58,31 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 
+// Prevent <windows.h> min/max definitions
+#define NOMINMAX
+
 #undef TRACE
-#undef MIN
-#undef MAX
 #undef ERROR
 #undef EV_BREAK
+
+#include <algorithm>
 
 #include <direct.h>
 #include <stdarg.h>
 #include <ctype.h> 
 #include <time.h>
 #include <malloc.h>
-#include <Windows.h>
+#include <windows.h>
 #undef ERROR
 #undef EV_BREAK
 #undef MOUSE_MOVED
 
 #include "Incursion.h"
 #undef ERROR
-#undef MIN
-#undef MAX
 
 #define TCOD_NOBASETYPES
 #include "libtcod.h"
 #undef ERROR
-#undef MIN
-#undef MAX
 
 
 #define CURSOR_BLINK_MS 300
@@ -1076,7 +1075,7 @@ void libtcodTerm::SClear() {
 }
 
 void  libtcodTerm::BlitScrollLine(int16 wn, int32 buffline, int32 winline) {
-    TCOD_console_blit(bScroll,0,buffline,min(SCROLL_WIDTH,WinSizeX()),1,bScreen,Windows[wn].Left,winline+Windows[wn].Top,1.0f,1.0f);
+    TCOD_console_blit(bScroll,0,buffline,std::min<int>(SCROLL_WIDTH,WinSizeX()),1,bScreen,Windows[wn].Left,winline+Windows[wn].Top,1.0f,1.0f);
 }
 
 /*****************************************************************************\

--- a/src/yygram.cpp
+++ b/src/yygram.cpp
@@ -1941,7 +1941,7 @@ int attack_entry ()
 
                                  if (at == A_ABIL)
 
-                                   theMon->Attk[CurrAttk].u.a.DC = max(
+                                   theMon->Attk[CurrAttk].u.a.DC = std::max(
 
                                         theMon->Attk[CurrAttk].u.a.DC, 1);
 
@@ -5057,7 +5057,7 @@ int domain_entry ()
          case 805: {
             res_ref(&rr);
 #line 907 "../lang/grammar.acc"
- theDom->Spells[min(sp,8)] = rr; sp++; 
+ theDom->Spells[std::min<int>(sp,8)] = rr; sp++; 
 # line 5062 "../src/yygram.cpp"
             switch (yyselect()) {
             case 804: {
@@ -5190,7 +5190,7 @@ int god_entry ()
          case 813: {
             res_ref(&rr);
 #line 926 "../lang/grammar.acc"
- theGod->Domains[min(dm,5)] = rr; dm++; 
+ theGod->Domains[std::min<int>(dm,5)] = rr; dm++; 
 # line 5195 "../src/yygram.cpp"
             switch (yyselect()) {
             case 812: {
@@ -6548,7 +6548,7 @@ int temp_attack_entry ()
 
                                  if (at == A_ABIL)
 
-                                   theTemp->NewAttk[CurrAttk].u.a.DC = max(
+                                   theTemp->NewAttk[CurrAttk].u.a.DC = std::max(
 
                                         theTemp->NewAttk[CurrAttk].u.a.DC, 1);
 
@@ -9604,7 +9604,7 @@ int param_list (pBSysFunc b, YYSTYPE fn, VBlock *bl, int *narg)
         if (PStorage[i] == RT_REGISTER)
           FreeRegister((int16)PValue[i]);
         }
-      *narg = max(*narg,b->ParamCount);
+      *narg = std::max<int>(*narg,b->ParamCount);
       Done:;
       
 # line 9611 "../src/yygram.cpp"
@@ -27147,7 +27147,7 @@ int yycoordinate[] = {
 /* 3968 */ 907011,
 /* 3969 */ 9999,
 /* 3970 */ 907018,
-/* 3971 */ 907072,
+/* 3971 */ 907082,
 /* 3972 */ 907024,
 /* 3973 */ 9999,
 /* 3974 */ 907024,
@@ -27157,10 +27157,10 @@ int yycoordinate[] = {
 /* 3978 */ 9999,
 /* 3979 */ 9999,
 /* 3980 */ 9999,
-/* 3981 */ 907073,
+/* 3981 */ 907083,
 /* 3982 */ 9999,
 /* 3983 */ 9999,
-/* 3984 */ 907073,
+/* 3984 */ 907083,
 /* 3985 */ 9999,
 /* 3986 */ 9999,
 /* 3987 */ 9999,
@@ -27261,7 +27261,7 @@ int yycoordinate[] = {
 /* 4082 */ 926012,
 /* 4083 */ 9999,
 /* 4084 */ 926019,
-/* 4085 */ 926074,
+/* 4085 */ 926084,
 /* 4086 */ 926025,
 /* 4087 */ 9999,
 /* 4088 */ 926025,
@@ -27271,10 +27271,10 @@ int yycoordinate[] = {
 /* 4092 */ 9999,
 /* 4093 */ 9999,
 /* 4094 */ 9999,
-/* 4095 */ 926075,
+/* 4095 */ 926085,
 /* 4096 */ 9999,
 /* 4097 */ 9999,
-/* 4098 */ 926075,
+/* 4098 */ 926085,
 /* 4099 */ 9999,
 /* 4100 */ 9999,
 /* 4101 */ 9999,


### PR DESCRIPTION
The simplest solution was to add a `using` alias to replace the macros with the C++ functions.

Platform toolset has been increased to v143. This was probably not needed for this PR but it is needed for C++17 and libtcod.

An explicit type must be given when int constants are mixed with smaller types. This mostly meant going around and adding `<int>` to everything.

The sources which needed to be updated includes `Grammar.acc`.

Unless there's anything unexpected, this closes #12

I'll look at this again when I'm more awake before marking this as ready.