### PR TITLE
Simplify working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These instructions are intended to allow you to get Incursion to the point where
 3. Open `build\Incursion.sln` in Visual Studio 2022.
 4. Ensure `exe_libtcod` is the default project. If it is not, right click on it and select "Set as Startup Project".
 5. Build a Debug solution.
-6. Run the built `Incursion.exe` with the command-line `Incursion.exe -compile` with a current directory of the top-level source directory. The module compilation code is not built into Release builds. It should generate a `mod\Incursion.mod` file which provides the game rules, setting and other things.
+6. Run the built `Incursion.exe` with the command-line `build/Win32/Debug/exe_libtcod/Incursion.exe -compile` with a current directory of the top-level source directory. The module compilation code is not built into Release builds. It should generate a `mod\Incursion.mod` file which provides the game rules, setting and other things.
 
 Note that there are custom build steps in Debug configurations that update this resource compiler, under the "Language Files" folder within Visual Studio. `tokens.lex` is parsed by `flex.exe`. `grammar.acc` is parsed by `modaccent.exe`. These steps may need to be disabled to compile the x64 Debug build as `modaccent.exe` is based on old external code that is not 64-bit compatible at this time. The output files of both steps are checked in and only deleted by rerunning these steps, so running them is not necessary and if it is, it can be done in Win32 Debug configuration.
 

--- a/build/exe_curses.vcxproj
+++ b/build/exe_curses.vcxproj
@@ -82,7 +82,7 @@ INCURSIONFONTPATH=$(SolutionDir)..\fonts
 INCURSIONLIBPATH=$(SolutionDir)..\lib
 $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerWorkingDirectory>$(SolutionDir)run</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)\..</LocalDebuggerWorkingDirectory>
     <LocalDebuggerCommandArguments>
     </LocalDebuggerCommandArguments>
   </PropertyGroup>
@@ -95,7 +95,7 @@ INCURSIONFONTPATH=$(SolutionDir)..\fonts
 INCURSIONLIBPATH=$(SolutionDir)..\lib
 $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerWorkingDirectory>$(SolutionDir)run</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)\..</LocalDebuggerWorkingDirectory>
     <LocalDebuggerCommandArguments />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -108,7 +108,7 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
 INCURSIONFONTPATH=$(SolutionDir)..\fonts
 INCURSIONLIBPATH=$(SolutionDir)..\lib
 $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
-    <LocalDebuggerWorkingDirectory>$(SolutionDir)run</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)\..</LocalDebuggerWorkingDirectory>
     <LocalDebuggerCommandArguments>
     </LocalDebuggerCommandArguments>
   </PropertyGroup>
@@ -121,7 +121,7 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
 INCURSIONFONTPATH=$(SolutionDir)..\fonts
 INCURSIONLIBPATH=$(SolutionDir)..\lib
 $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
-    <LocalDebuggerWorkingDirectory>$(SolutionDir)run</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)\..</LocalDebuggerWorkingDirectory>
     <LocalDebuggerCommandArguments />
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -144,7 +144,6 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       </IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)run" mkdir "$(SolutionDir)run"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -166,7 +165,6 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       </IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)run" mkdir "$(SolutionDir)run"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -190,7 +188,6 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       </IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)run" mkdir "$(SolutionDir)run"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -213,7 +210,6 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       </IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)run" mkdir "$(SolutionDir)run"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/build/exe_libtcod.vcxproj
+++ b/build/exe_libtcod.vcxproj
@@ -87,7 +87,7 @@ INCURSIONFONTPATH=$(SolutionDir)..\fonts
 INCURSIONLIBPATH=$(SolutionDir)..\lib
 $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerWorkingDirectory>$(SolutionDir)run</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)\..</LocalDebuggerWorkingDirectory>
     <LocalDebuggerCommandArguments>
     </LocalDebuggerCommandArguments>
   </PropertyGroup>
@@ -101,7 +101,7 @@ INCURSIONFONTPATH=$(SolutionDir)..\fonts
 INCURSIONLIBPATH=$(SolutionDir)..\lib
 $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerWorkingDirectory>$(SolutionDir)run</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)\..</LocalDebuggerWorkingDirectory>
     <LocalDebuggerCommandArguments />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -115,7 +115,7 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
 INCURSIONFONTPATH=$(SolutionDir)..\fonts
 INCURSIONLIBPATH=$(SolutionDir)..\lib
 $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
-    <LocalDebuggerWorkingDirectory>$(SolutionDir)run</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)\..</LocalDebuggerWorkingDirectory>
     <LocalDebuggerCommandArguments>
     </LocalDebuggerCommandArguments>
   </PropertyGroup>
@@ -129,7 +129,7 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
 INCURSIONFONTPATH=$(SolutionDir)..\fonts
 INCURSIONLIBPATH=$(SolutionDir)..\lib
 $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
-    <LocalDebuggerWorkingDirectory>$(SolutionDir)run</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)\..</LocalDebuggerWorkingDirectory>
     <LocalDebuggerCommandArguments />
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -154,7 +154,6 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       </Command>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)run" mkdir "$(SolutionDir)run"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -180,7 +179,6 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       </Command>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)run" mkdir "$(SolutionDir)run"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -207,7 +205,6 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       </Command>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)run" mkdir "$(SolutionDir)run"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -235,7 +232,6 @@ $(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
       </Command>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)run" mkdir "$(SolutionDir)run"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/Wcurses.cpp
+++ b/src/Wcurses.cpp
@@ -397,35 +397,8 @@ ExceptionHandler* crashdumpHandler;
 int main(int argc, char *argv[]) {
     /* This path code is currently present in libtcod and curses code. */
     char executablePath[MAX_PATH_LENGTH] = "";
-    char *envPath = getenv("INCURSIONPATH");
-
-    if (envPath != NULL) {
-        if (strlen(envPath) > 0 && strcat(executablePath, envPath)) {
-            if (executablePath[strlen(executablePath) - 1] != '\\')
-                strncat(executablePath, "\\", 1);
-        }
-    }
-
-    if (strlen(executablePath) == 0) {
-        /* If run normally, check to see from which directory, and if there is one, use it. */
-        if (!IsDebuggerPresent() && argc >= 1) {
-            /* argv[0] is the filename and maybe the path before it, if the path is there grab it. */
-            const char *str = strrchr(argv[0], '\\');
-            if (str != NULL) {
-                int16 n = str - argv[0]; /* Copy the separator too. */
-                if (!strncpy(executablePath, argv[0], n))
-                    Error("Failed to locate Incursion directory for '%s'", argv[0]);
-                executablePath[n] = '\0';
-            }
-        }
-    }
-
-    /* If run under the debugger, or from within the current directory, or if
-    something went wrong above, get and use the current directory path. */
-    if (strlen(executablePath) == 0) {
-        if (!_getcwd(executablePath, MAX_PATH_LENGTH))
-            Error("Failed to locate Incursion directory under debugger (error 23)");
-    }
+    _getcwd(executablePath, sizeof(executablePath));
+    const char *envPath = getenv("INCURSIONPATH");
 
     /* Google Breakpad is only compiled into Release builds, which get distributed.
      * Debug builds get the option to break out into the debugger, which makes it
@@ -444,7 +417,7 @@ int main(int argc, char *argv[]) {
 
 	theGame = new Game();
     AT1 = new cursesTerm;
-	AT1->SetIncursionDirectory(executablePath);
+	AT1->SetIncursionDirectory(envPath ? envPath : executablePath);
     T1 = AT1;
     int retval = 0;
 

--- a/src/Wlibtcod.cpp
+++ b/src/Wlibtcod.cpp
@@ -334,39 +334,12 @@ libtcodTerm *AT1;
 int main(int argc, char *argv[]) {
     /* This path code is currently present in libtcod and curses code. */
     char executablePath[MAX_PATH_LENGTH] = "";
-    char *envPath = getenv("INCURSIONPATH");
-
-    if (envPath != NULL) {
-        if (strlen(envPath) > 0 && strcat(executablePath, envPath)) {
-            if (executablePath[strlen(executablePath) - 1] != '\\')
-                strncat(executablePath, "\\", 1);
-        }
-    }
-
-    if (strlen(executablePath) == 0) {
-        /* If run normally, check to see from which directory, and if there is one, use it. */
-        if (!IsDebuggerPresent() && argc >= 1) {
-            /* argv[0] is the filename and maybe the path before it, if the path is there grab it. */
-            const char *str = strrchr(argv[0], '\\');
-            if (str != NULL) {
-                int16 n = str - argv[0]; /* Copy the separator too. */
-                if (!strncpy(executablePath, argv[0], n))
-                    Error("Failed to locate Incursion directory for '%s'", argv[0]);
-                executablePath[n] = '\0';
-            }
-        }
-    }
-
-    /* If run under the debugger, or from within the current directory, or if
-       something went wrong above, get and use the current directory path. */
-    if (strlen(executablePath) == 0) {
-        if (!_getcwd(executablePath, MAX_PATH_LENGTH))
-            Error("Failed to locate Incursion directory under debugger (error 23)");
-    }
+    _getcwd(executablePath, sizeof(executablePath));
+    const char *envPath = getenv("INCURSIONPATH");
 
     theGame = new Game();
     AT1 = new libtcodTerm;
-    AT1->SetIncursionDirectory(executablePath);
+    AT1->SetIncursionDirectory(envPath ? envPath : executablePath);
     T1 = AT1;
     int retval = 0;
 


### PR DESCRIPTION
The default working directory is now the project root folder, always. This is simpler, removes the need to copy files around, and resolves edge cases. Closes #1

Any older save files in `build/run` will have to be moved to the project root folder in order to continue them.

I've noticed Incursion breaks with relative paths, otherwise I would've used `"."` as the default directory rather than asking `_getcwd`.

Tested `-compile`. Specifically running the program remotely with `./build/Win32/Debug/exe_libtcod/Incursion.exe -compile`, which previously did not work. Tested loading an old character.