### PR TITLE
Bounds-check Map::GetAt() instead of returning the (0,0) square

### DIFF
--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -620,6 +620,21 @@ Thing* Map::GetAt(int16 x, int16 y, int16 t, bool first)
     //if (count > 1000000L)
     //  __asm int 3;
     
+    /* Nothing exists outside the map. Callers scan neighbouring squares
+       without checking first -- Monster::ChooseAction() does it for all eight
+       neighbours of a hiding monster -- and At() answers an out-of-bounds
+       query with the (0,0) square instead of failing, so the wrong answer
+       looks like a real one. Refuse here: every FCreatureAt/NCreatureAt/
+       FTrapAt/FirstAt accessor funnels through this function, so one guard
+       covers them all. */
+    if (!InBounds(x,y)) {
+        if (first) {
+            doneflag = true;
+            curr = NULL;
+        }
+        return NULL;
+    }
+
     if (first == true) 
       {
         doneflag = false;


### PR DESCRIPTION
Fixes #40, where the full analysis and measurements are.

`Map::At()` answers an out-of-bounds query by returning `Grid[0]` -- the square at (0,0) -- rather than failing, and `Map::GetAt()` does not check its coordinates. A hiding monster at a map edge therefore makes AI decisions from the contents of the top-left corner. Measured at 343 out-of-bounds reads in 13 seconds of ordinary play.

The guard goes in `Map::GetAt()` rather than in `Monster::ChooseAction()`, because every `FCreatureAt`/`NCreatureAt`/`FTrapAt`/`FirstAt` accessor funnels through that one function. Fixing the caller alone would leave the siblings broken.

15 added lines, no deletions, no reformatting. Verified by play on a macOS/POSIX build: 877 turns over 583 seconds with an empty error log, against 444 errors in 13 seconds beforehand. The change touches no platform-specific code, so it should behave identically on the MSVC builds -- though I have not been able to test those.

Happy to reshape this however you prefer, or to close it and leave just the issue if you would rather patch it yourself.