### PR TITLE
Zero-initialise Target at its eight construction sites

### DIFF
--- a/src/Monster.cpp
+++ b/src/Monster.cpp
@@ -691,7 +691,7 @@ SkipShifting:
       int16 ic;
       ic = 0;
       for (it=m->FItemAt(x,y);it;it=m->NItemAt(x,y)) {
-        Target newT;
+        Target newT = {};
         ts.RateAsTarget(this,it,newT);
         i = newT.priority;
         if (ic > 20)

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -974,7 +974,7 @@ bool TargetSystem::addTarget(Target &newT)
 
 bool TargetSystem::addCreatureTarget(Creature *targ, TargetType type)
 {
-  Target newT;
+  Target newT = {};
   newT.type = type;
   newT.data.Creature.c = targ->myHandle;
   newT.priority = 30; 
@@ -1019,7 +1019,7 @@ bool TargetSystem::giveOrder(Creature * me, Creature *master, TargetType order, 
    
   } 
 
-  Target newT;
+  Target newT = {};
   newT.type = order;
   if (victim && victim->isCreature()) 
     newT.data.Creature.c = victim->myHandle; 
@@ -1302,7 +1302,7 @@ void TargetSystem::Consider(Creature *me, Thing *t)
   if (hasTargetThing(t))
     return;
 
-  Target newT;
+  Target newT = {};
 
   RateAsTarget(me,t,newT);
 
@@ -1321,7 +1321,7 @@ void TargetSystem::HearNoise(Creature *me, uint8 x, uint8 y)
     Consider(me,c);
   } else {
     // investigate!
-    Target newT;
+    Target newT = {};
     newT.type = TargetArea;
     newT.priority = 1;
     newT.why.Set(TargetHeardNoise);
@@ -1349,7 +1349,7 @@ void TargetSystem::Wanderlust(Creature *me, Thing *wander_to)
       }
     if (me->m->SolidAt(x,y))
       continue;
-    Target newT;
+    Target newT = {};
     newT.type = TargetWander;
     newT.priority = wander_to ? 40 : 1;
     newT.why.Set(TargetWanderlust);
@@ -1383,7 +1383,7 @@ void TargetSystem::Liberate(Creature *me, Creature *lib)
       }
     else
       {
-        Target newT;
+        Target newT = {};
         newT.type = TargetEnemy;
         newT.priority = 50;
         newT.why.Set(TargetLiberated);
@@ -1491,7 +1491,7 @@ void TargetSystem::ItHitMe(Creature *me, Creature *t, int16 damage) {
     MapIterate(me->m,cr,i)
         if (cr->isCreature())
             if (cr->isFriendlyTo(me) && !cr->isHostileTo(t)) {
-                Target newT;
+                Target newT = {};
                 newT.type = TargetEnemy;
                 newT.priority = 20;
                 newT.why.Set(TargetHitMe);


### PR DESCRIPTION
TargetSystem::giveOrder builds its Target uninitialised. An order often has
neither a victim nor a point, so both of the assignments that would fill
newT.data are skipped and the union keeps whatever was on the stack.
Encounter.cpp gives a formation's escorts OrderWalkNearMe with neither, and six
sites in Social.cpp do the same.

Target::GetThingOrNULL reads data.Creature.c in its default branch, and the
Order types fall into that branch. Monster::Movement sets `follow` correctly
from getLeader() and then OVERRIDES it whenever that garbage happens to resolve
to a live object -- casting a non-creature to Creature* and reading ->x and ->y
off it. An escort stops following its leader and walks toward an arbitrary
object instead.

Two of the eight sites, addCreatureTarget and Liberate, never set
damageDoneToMe either. ItHitMe accumulates into that field and turns a creature
hostile past a threshold of roughly 5 to 15, so garbage there made an escort
turn on its own leader after one stray hit.

Zero is the value every reader already handles:

  * Target.cpp, GetThingOrNULL default branch, tests `data.Creature.c &&`
    before resolving, so a zero handle returns NULL.
  * Registry::Exists returns false for handle 0, so the TargetItem branch is
    safe as well.
  * Zeroing sets type to TargetInvalid and why.type to TargetDefault, and
    TargetDefault routes every reader away from the bytes that aggregate
    initialisation does not guarantee.

Target is an aggregate -- no user-declared constructors, no bases, no virtual
functions -- so `= {}` is valid aggregate initialisation, and `{ }` is in the
C++98 initializer-clause grammar. inc/Target.h is untouched, so sizeof(Target)
and every member offset are unchanged; this does not alter the save format.

MEASURED over 250 seeds of a scripted dungeon-diving session, same build, same
module data, the change being the only difference:

    assert lines at Base.h:577      89,545 -> 0
    total error lines              139,948 -> 48,245

Every session in both arms reached gameplay.

---

Edit: removed a figure ("all 32,614 occurrences were target type 17") that came from an earlier diagnostic build I did not reproduce myself. It was illustrative; the claim this patch rests on is the 250-seed measurement above.
