### PR TITLE
Player::MoveDepth: make GoWith re-entrant, and bound it (hardening, not a crash fix)

### DIFF
--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -852,7 +852,11 @@ void Thing::MoveDepth(int16 NewDepth, bool safe) {
 }
 
 void Player::MoveDepth(int16 NewDepth, bool safe) {
-    static Thing *GoWith[64]; Creature *c;
+    /* Not static: this function re-enters itself. PlaceAt below fires the new
+       square's terrain, and terrain can move the player another level. One
+       shared array means the inner call refills it while the outer call still
+       holds a count of its own contents. */
+    Thing *GoWith[64]; Creature *c;
     rID mID; Map *new_m = NULL; int16 nx, ny, i, gwc;
     StoreLevelStats((uint8)m->Depth);
     theGame->SaveGame(*this);
@@ -906,6 +910,10 @@ void Player::MoveDepth(int16 NewDepth, bool safe) {
         MapIterate(m, c, i)
             if (c->isMonster())
                 if (c->ts.isLeader(this)) {
+                    /* A player with more than 64 followers leaves the rest
+                       behind rather than writing past the array. */
+                    if (gwc >= (int16)(sizeof(GoWith)/sizeof(GoWith[0])))
+                        break;
                     GoWith[gwc++] = c;
                     c->Remove(false);
                 }


### PR DESCRIPTION
This is hardening. It is not offered as a fix for any reported crash, and the
section at the end says what it was measured NOT to do.

Player::MoveDepth declares its list of travelling followers as
`static Thing *GoWith[64]`, and the function re-enters itself. It calls PlaceAt
to put the player on the new level, PlaceAt fires the new square's terrain, and
terrain can move the player another level (Feature.cpp, Move.cpp).

With one shared array the inner call refills it while the outer call still holds
`gwc`, a stack local, describing its own contents. When the outer call resumes it
walks its own count over the inner call's entries.

Dropping `static` gives each invocation its own array. The cost is 512 bytes of
stack.

The fill loop is also unbounded: it writes GoWith[gwc++] once per creature that
leads the player, with no test against the size of the array. A player with more
than 64 followers writes past the end. The bound leaves the surplus behind rather
than overrunning. `break` is safe here because MapIterate expands to a plain for
loop with no cleanup.

WHAT THIS DOES NOT DO. A controlled A/B ran 250 seeds of a scripted
dungeon-diving session against two builds differing only by the `static` keyword,
with the same module data and the same seeds. One seed segfaults in
Player::MoveDepth, and it segfaults identically with and without this change; the
two crash reports are the same NULL dereference on the same stack, with MoveDepth
re-entered through PlaceAt and TerrainEffects. The re-entrancy is real and
observable, but this change does not repair that crash.

One other seed crashes without the change and not with it, in an unrelated place
(Creature::isMType under Magic::Blast). Changing where followers land changes
which later states a seed reaches, so that seed stops arriving at a pre-existing
bug. That is state perturbation, and it is not evidence for this patch.

The remaining suspect, untested: the outer call also holds `Map *new_m` across
the re-entrant call, and the inner call can change level again underneath it.
MoveDepth additionally calls SaveGame() at its top, so a terrain-triggered depth
change saves the game from inside a depth change.