### PR TITLE
Compare handles, not addresses, in TargetSort

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -1185,7 +1185,29 @@ static int TargetSort(const void *a, const void *b)
   else if (l->type == TargetInvalid) return 999;
   else if (r->priority == l->priority) {
     if (r->type == l->type) {
-      return (r->GetThingOrNULL() - l->GetThingOrNULL());
+      /* Two targets that tie on priority and type were ordered by SUBTRACTING
+         THE TWO OBJECTS' ADDRESSES. Every platform places the heap somewhere
+         different on each launch, so equal targets sorted into a different
+         order on every run of the same seed. Readers of this list take the
+         first match, so a monster picked a different target, and from that one
+         decision the game went a different way.
+
+         A handle is an identity the game assigns itself, so it answers the
+         same question and gives the same answer every time. The direction is
+         unchanged -- the larger of the two still sorts first -- and a NULL
+         Thing sorts as it did before, since it gave address 0 and now gives
+         handle 0.
+
+         The subtraction was wrong a second way: it is a pointer difference
+         returned as an int, so on a 64-bit build with a large heap even its
+         sign was not dependable. */
+      Thing *lt = l->GetThingOrNULL(),
+            *rt = r->GetThingOrNULL();
+      hObj lh = lt ? lt->myHandle : 0,
+           rh = rt ? rt->myHandle : 0;
+      if (rh == lh)
+        return 0;
+      return rh > lh ? 1 : -1;
     } else return (r->type - l->type); 
   } else return (r->priority - l->priority); 
 }


### PR DESCRIPTION
Compare handles, not addresses, in TargetSort

TargetSort breaks a tie between two targets of equal priority and equal type by
subtracting the two objects' addresses. Every reader of the sorted list takes
the first match, so this decides which target a monster acts on, and every
platform places the heap somewhere different on each launch. The same seed
therefore produces a different target order and, from there, a different game.

It is wrong a second way that needs no run to see: the subtraction is a pointer
difference returned as an int, so on a 64-bit build with a large heap the result
can truncate to the wrong sign. A comparator that is not consistent with itself
is undefined behaviour in qsort regardless of the ordering question.

Thing::myHandle answers the same question with an identity the game assigns
itself, so it gives the same answer on every run. The sign convention is
unchanged, NULL sorts as it did, inc/Target.h is untouched and the save format
is unaffected.

Measured on a scripted dungeon-diving session, screens compared byte for byte:

    seed 8, before      6 runs, 1 diverged
    seed 8, after      18 runs, 18 identical

and under a debugger, changing nothing but address randomisation:

    randomisation off  30 runs, 30 identical, 1 outcome
    randomisation on   15 runs,  4 diverged,  3 outcomes

This is not the only such site. A different seed still diverges after this
change, inside Map::Generate, and that build is likewise identical ten times out
of ten with randomisation disabled. This removes one site and claims nothing
about the rest.

git blame puts the line in the 2014 import, so it is not an artefact of the
POSIX port this came from.

Drafted with AI assistance (Claude). The measurements were run and reviewed by
Brian Hill.
